### PR TITLE
fix e2e tests due to git-filter-repo renames

### DIFF
--- a/e2e-tests/data/autoprov_ha_appinst_failedover.yml
+++ b/e2e-tests/data/autoprov_ha_appinst_failedover.yml
@@ -59,6 +59,39 @@ regiondata:
           clusterkey:
             name: autocluster-autoprov
           cloudletkey:
+            organization: dmuus
+            name: dmuus-cloud-1
+          organization: MobiledgeX
+      cloudletloc:
+        latitude: 31
+        longitude: -91
+      uri: shared.dmuus-cloud-1-dmuus.local.mobiledgex.net
+      liveness: Autoprov
+      mappedports:
+      - proto: Tcp
+        internalport: 82
+        publicport: 82
+      flavor:
+        name: x1.small
+      state: Ready
+      runtimeinfo:
+        containerids:
+        - appOnClusterNode0
+      healthcheck: Ok
+      powerstate: PowerOn
+      vmflavor: x1.small
+      realclustername: Reservable1
+      uniqueid: acmeappcoautoprovha10-autocluster-autoprov-dmuus-cloud-1-dmuus
+      dnslabel: autoprovha10-acmeappco
+    - key:
+        appkey:
+          organization: AcmeAppCo
+          name: autoprovHA
+          version: "1.0"
+        clusterinstkey:
+          clusterkey:
+            name: autocluster-autoprov
+          cloudletkey:
             organization: gcp
             name: gcp-cloud-5
           organization: MobiledgeX
@@ -83,37 +116,4 @@ regiondata:
       vmflavor: x1.small
       realclustername: Reservable4
       uniqueid: acmeappcoautoprovha10-autocluster-autoprov-gcp-cloud-5-gcp
-      dnslabel: autoprovha10-acmeappco
-    - key:
-        appkey:
-          organization: AcmeAppCo
-          name: autoprovHA
-          version: "1.0"
-        clusterinstkey:
-          clusterkey:
-            name: autocluster-autoprov
-          cloudletkey:
-            organization: dmuus
-            name: dmuus-cloud-1
-          organization: MobiledgeX
-      cloudletloc:
-        latitude: 31
-        longitude: -91
-      uri: shared.dmuus-cloud-1-dmuus.local.mobiledgex.net
-      liveness: Autoprov
-      mappedports:
-      - proto: Tcp
-        internalport: 82
-        publicport: 82
-      flavor:
-        name: x1.small
-      state: Ready
-      runtimeinfo:
-        containerids:
-        - appOnClusterNode0
-      healthcheck: Ok
-      powerstate: PowerOn
-      vmflavor: x1.small
-      realclustername: Reservable1
-      uniqueid: acmeappcoautoprovha10-autocluster-autoprov-dmuus-cloud-1-dmuus
       dnslabel: autoprovha10-acmeappco

--- a/e2e-tests/data/federation_partner_federator_show1.yml
+++ b/e2e-tests/data/federation_partner_federator_show1.yml
@@ -13,26 +13,6 @@
 # limitations under the License.
 
 federators:
-- federationid: partner1-PA-enterprise-SA
-  operatorid: partner1
-  countrycode: PA
-  federationaddr: 127.0.0.1:9808
-  region: PA
-  mcc: "123"
-  mnc:
-  - "111"
-  - "222"
-  - "333"
-- federationid: partner1-PA-enterprise-SB
-  operatorid: partner1
-  countrycode: PA
-  federationaddr: 127.0.0.1:9808
-  region: PA
-  mcc: "123"
-  mnc:
-  - "111"
-  - "222"
-  - "333"
 - federationid: partner1-PA-dmuus-SA
   operatorid: partner1
   countrycode: PA
@@ -44,6 +24,26 @@ federators:
   - "222"
   - "333"
 - federationid: partner1-PA-dmuus-SB
+  operatorid: partner1
+  countrycode: PA
+  federationaddr: 127.0.0.1:9808
+  region: PA
+  mcc: "123"
+  mnc:
+  - "111"
+  - "222"
+  - "333"
+- federationid: partner1-PA-enterprise-SA
+  operatorid: partner1
+  countrycode: PA
+  federationaddr: 127.0.0.1:9808
+  region: PA
+  mcc: "123"
+  mnc:
+  - "111"
+  - "222"
+  - "333"
+- federationid: partner1-PA-enterprise-SB
   operatorid: partner1
   countrycode: PA
   federationaddr: 127.0.0.1:9808

--- a/e2e-tests/data/federation_partner_federator_show2.yml
+++ b/e2e-tests/data/federation_partner_federator_show2.yml
@@ -13,26 +13,6 @@
 # limitations under the License.
 
 federators:
-- federationid: partner2-PS-enterprise-SA
-  operatorid: partner2
-  countrycode: PS
-  federationaddr: 127.0.0.1:9809
-  region: PS
-  mcc: "123"
-  mnc:
-  - "111"
-  - "222"
-  - "333"
-- federationid: partner2-PS-enterprise-SB
-  operatorid: partner2
-  countrycode: PS
-  federationaddr: 127.0.0.1:9809
-  region: PS
-  mcc: "123"
-  mnc:
-  - "111"
-  - "222"
-  - "333"
 - federationid: partner2-PS-dmuus-SA
   operatorid: partner2
   countrycode: PS
@@ -44,6 +24,26 @@ federators:
   - "222"
   - "333"
 - federationid: partner2-PS-dmuus-SB
+  operatorid: partner2
+  countrycode: PS
+  federationaddr: 127.0.0.1:9809
+  region: PS
+  mcc: "123"
+  mnc:
+  - "111"
+  - "222"
+  - "333"
+- federationid: partner2-PS-enterprise-SA
+  operatorid: partner2
+  countrycode: PS
+  federationaddr: 127.0.0.1:9809
+  region: PS
+  mcc: "123"
+  mnc:
+  - "111"
+  - "222"
+  - "333"
+- federationid: partner2-PS-enterprise-SB
   operatorid: partner2
   countrycode: PS
   federationaddr: 127.0.0.1:9809

--- a/e2e-tests/data/federation_partner_self_show1.yml
+++ b/e2e-tests/data/federation_partner_self_show1.yml
@@ -13,32 +13,6 @@
 # limitations under the License.
 
 federations:
-- name: partner1-PA-enterprise-SA-fed
-  selffederationid: partner1-PA-enterprise-SA
-  selfoperatorid: partner1
-  federator:
-    federationid: enterprise-SA-partner1-PA
-    operatorid: enterprise
-    countrycode: SA
-    federationaddr: 127.0.0.1:9801
-    mcc: "456"
-    mnc:
-    - "444"
-    - "555"
-    - "666"
-- name: partner1-PA-enterprise-SB-fed
-  selffederationid: partner1-PA-enterprise-SB
-  selfoperatorid: partner1
-  federator:
-    federationid: enterprise-SB-partner1-PA
-    operatorid: enterprise
-    countrycode: SB
-    federationaddr: 127.0.0.1:9801
-    mcc: "789"
-    mnc:
-    - "777"
-    - "888"
-    - "999"
 - name: partner1-PA-dmuus-SA-fed
   selffederationid: partner1-PA-dmuus-SA
   selfoperatorid: partner1
@@ -65,3 +39,29 @@ federations:
     - "444"
     - "555"
     - "666"
+- name: partner1-PA-enterprise-SA-fed
+  selffederationid: partner1-PA-enterprise-SA
+  selfoperatorid: partner1
+  federator:
+    federationid: enterprise-SA-partner1-PA
+    operatorid: enterprise
+    countrycode: SA
+    federationaddr: 127.0.0.1:9801
+    mcc: "456"
+    mnc:
+    - "444"
+    - "555"
+    - "666"
+- name: partner1-PA-enterprise-SB-fed
+  selffederationid: partner1-PA-enterprise-SB
+  selfoperatorid: partner1
+  federator:
+    federationid: enterprise-SB-partner1-PA
+    operatorid: enterprise
+    countrycode: SB
+    federationaddr: 127.0.0.1:9801
+    mcc: "789"
+    mnc:
+    - "777"
+    - "888"
+    - "999"

--- a/e2e-tests/data/federation_partner_self_show2.yml
+++ b/e2e-tests/data/federation_partner_self_show2.yml
@@ -13,32 +13,6 @@
 # limitations under the License.
 
 federations:
-- name: partner2-PS-enterprise-SA-fed
-  selffederationid: partner2-PS-enterprise-SA
-  selfoperatorid: partner2
-  federator:
-    federationid: enterprise-SA-partner2-PS
-    operatorid: enterprise
-    countrycode: SA
-    federationaddr: 127.0.0.1:9801
-    mcc: "456"
-    mnc:
-    - "444"
-    - "555"
-    - "666"
-- name: partner2-PS-enterprise-SB-fed
-  selffederationid: partner2-PS-enterprise-SB
-  selfoperatorid: partner2
-  federator:
-    federationid: enterprise-SB-partner2-PS
-    operatorid: enterprise
-    countrycode: SB
-    federationaddr: 127.0.0.1:9801
-    mcc: "789"
-    mnc:
-    - "777"
-    - "888"
-    - "999"
 - name: partner2-PS-dmuus-SA-fed
   selffederationid: partner2-PS-dmuus-SA
   selfoperatorid: partner2
@@ -65,3 +39,29 @@ federations:
     - "444"
     - "555"
     - "666"
+- name: partner2-PS-enterprise-SA-fed
+  selffederationid: partner2-PS-enterprise-SA
+  selfoperatorid: partner2
+  federator:
+    federationid: enterprise-SA-partner2-PS
+    operatorid: enterprise
+    countrycode: SA
+    federationaddr: 127.0.0.1:9801
+    mcc: "456"
+    mnc:
+    - "444"
+    - "555"
+    - "666"
+- name: partner2-PS-enterprise-SB-fed
+  selffederationid: partner2-PS-enterprise-SB
+  selfoperatorid: partner2
+  federator:
+    federationid: enterprise-SB-partner2-PS
+    operatorid: enterprise
+    countrycode: SB
+    federationaddr: 127.0.0.1:9801
+    mcc: "789"
+    mnc:
+    - "777"
+    - "888"
+    - "999"

--- a/e2e-tests/data/federation_self_federator_show.yml
+++ b/e2e-tests/data/federation_self_federator_show.yml
@@ -13,46 +13,6 @@
 # limitations under the License.
 
 federators:
-- federationid: enterprise-SA-partner1-PA
-  operatorid: enterprise
-  countrycode: SA
-  federationaddr: 127.0.0.1:9801
-  region: local
-  mcc: "456"
-  mnc:
-  - "444"
-  - "555"
-  - "666"
-- federationid: enterprise-SA-partner2-PS
-  operatorid: enterprise
-  countrycode: SA
-  federationaddr: 127.0.0.1:9801
-  region: local
-  mcc: "456"
-  mnc:
-  - "444"
-  - "555"
-  - "666"
-- federationid: enterprise-SB-partner1-PA
-  operatorid: enterprise
-  countrycode: SB
-  federationaddr: 127.0.0.1:9801
-  region: locala
-  mcc: "789"
-  mnc:
-  - "777"
-  - "888"
-  - "999"
-- federationid: enterprise-SB-partner2-PS
-  operatorid: enterprise
-  countrycode: SB
-  federationaddr: 127.0.0.1:9801
-  region: locala
-  mcc: "789"
-  mnc:
-  - "777"
-  - "888"
-  - "999"
 - federationid: dmuus-SA-partner1-PA
   operatorid: dmuus
   countrycode: SA
@@ -85,6 +45,46 @@ federators:
   - "999"
 - federationid: dmuus-SB-partner2-PS
   operatorid: dmuus
+  countrycode: SB
+  federationaddr: 127.0.0.1:9801
+  region: locala
+  mcc: "789"
+  mnc:
+  - "777"
+  - "888"
+  - "999"
+- federationid: enterprise-SA-partner1-PA
+  operatorid: enterprise
+  countrycode: SA
+  federationaddr: 127.0.0.1:9801
+  region: local
+  mcc: "456"
+  mnc:
+  - "444"
+  - "555"
+  - "666"
+- federationid: enterprise-SA-partner2-PS
+  operatorid: enterprise
+  countrycode: SA
+  federationaddr: 127.0.0.1:9801
+  region: local
+  mcc: "456"
+  mnc:
+  - "444"
+  - "555"
+  - "666"
+- federationid: enterprise-SB-partner1-PA
+  operatorid: enterprise
+  countrycode: SB
+  federationaddr: 127.0.0.1:9801
+  region: locala
+  mcc: "789"
+  mnc:
+  - "777"
+  - "888"
+  - "999"
+- federationid: enterprise-SB-partner2-PS
+  operatorid: enterprise
   countrycode: SB
   federationaddr: 127.0.0.1:9801
   region: locala

--- a/e2e-tests/data/federation_self_partner_federation_show.yml
+++ b/e2e-tests/data/federation_self_partner_federation_show.yml
@@ -13,62 +13,6 @@
 # limitations under the License.
 
 federations:
-- name: enterprise-SA-partner1-PA-fed
-  selffederationid: enterprise-SA-partner1-PA
-  selfoperatorid: enterprise
-  federator:
-    federationid: partner1-PA-enterprise-SA
-    operatorid: partner1
-    countrycode: PA
-    federationaddr: 127.0.0.1:9808
-    mcc: "123"
-    mnc:
-    - "111"
-    - "222"
-    - "333"
-  partnerrolesharezoneswithself: true
-- name: enterprise-SA-partner2-PS-fed
-  selffederationid: enterprise-SA-partner2-PS
-  selfoperatorid: enterprise
-  federator:
-    federationid: partner2-PS-enterprise-SA
-    operatorid: partner2
-    countrycode: PS
-    federationaddr: 127.0.0.1:9809
-    mcc: "123"
-    mnc:
-    - "111"
-    - "222"
-    - "333"
-  partnerrolesharezoneswithself: true
-- name: enterprise-SB-partner1-PA-fed
-  selffederationid: enterprise-SB-partner1-PA
-  selfoperatorid: enterprise
-  federator:
-    federationid: partner1-PA-enterprise-SB
-    operatorid: partner1
-    countrycode: PA
-    federationaddr: 127.0.0.1:9808
-    mcc: "123"
-    mnc:
-    - "111"
-    - "222"
-    - "333"
-  partnerrolesharezoneswithself: true
-- name: enterprise-SB-partner2-PS-fed
-  selffederationid: enterprise-SB-partner2-PS
-  selfoperatorid: enterprise
-  federator:
-    federationid: partner2-PS-enterprise-SB
-    operatorid: partner2
-    countrycode: PS
-    federationaddr: 127.0.0.1:9809
-    mcc: "123"
-    mnc:
-    - "111"
-    - "222"
-    - "333"
-  partnerrolesharezoneswithself: true
 - name: dmuus-SA-partner1-PA-fed
   selffederationid: dmuus-SA-partner1-PA
   selfoperatorid: dmuus
@@ -116,6 +60,62 @@ federations:
   selfoperatorid: dmuus
   federator:
     federationid: partner2-PS-dmuus-SB
+    operatorid: partner2
+    countrycode: PS
+    federationaddr: 127.0.0.1:9809
+    mcc: "123"
+    mnc:
+    - "111"
+    - "222"
+    - "333"
+  partnerrolesharezoneswithself: true
+- name: enterprise-SA-partner1-PA-fed
+  selffederationid: enterprise-SA-partner1-PA
+  selfoperatorid: enterprise
+  federator:
+    federationid: partner1-PA-enterprise-SA
+    operatorid: partner1
+    countrycode: PA
+    federationaddr: 127.0.0.1:9808
+    mcc: "123"
+    mnc:
+    - "111"
+    - "222"
+    - "333"
+  partnerrolesharezoneswithself: true
+- name: enterprise-SA-partner2-PS-fed
+  selffederationid: enterprise-SA-partner2-PS
+  selfoperatorid: enterprise
+  federator:
+    federationid: partner2-PS-enterprise-SA
+    operatorid: partner2
+    countrycode: PS
+    federationaddr: 127.0.0.1:9809
+    mcc: "123"
+    mnc:
+    - "111"
+    - "222"
+    - "333"
+  partnerrolesharezoneswithself: true
+- name: enterprise-SB-partner1-PA-fed
+  selffederationid: enterprise-SB-partner1-PA
+  selfoperatorid: enterprise
+  federator:
+    federationid: partner1-PA-enterprise-SB
+    operatorid: partner1
+    countrycode: PA
+    federationaddr: 127.0.0.1:9808
+    mcc: "123"
+    mnc:
+    - "111"
+    - "222"
+    - "333"
+  partnerrolesharezoneswithself: true
+- name: enterprise-SB-partner2-PS-fed
+  selffederationid: enterprise-SB-partner2-PS
+  selfoperatorid: enterprise
+  federator:
+    federationid: partner2-PS-enterprise-SB
     operatorid: partner2
     countrycode: PS
     federationaddr: 127.0.0.1:9809

--- a/e2e-tests/data/federation_self_partner_show.yml
+++ b/e2e-tests/data/federation_self_partner_show.yml
@@ -13,58 +13,6 @@
 # limitations under the License.
 
 federations:
-- name: enterprise-SA-partner1-PA-fed
-  selffederationid: enterprise-SA-partner1-PA
-  selfoperatorid: enterprise
-  federator:
-    federationid: partner1-PA-enterprise-SA
-    operatorid: partner1
-    countrycode: PA
-    federationaddr: 127.0.0.1:9808
-    mcc: "123"
-    mnc:
-    - "111"
-    - "222"
-    - "333"
-- name: enterprise-SA-partner2-PS-fed
-  selffederationid: enterprise-SA-partner2-PS
-  selfoperatorid: enterprise
-  federator:
-    federationid: partner2-PS-enterprise-SA
-    operatorid: partner2
-    countrycode: PS
-    federationaddr: 127.0.0.1:9809
-    mcc: "123"
-    mnc:
-    - "111"
-    - "222"
-    - "333"
-- name: enterprise-SB-partner1-PA-fed
-  selffederationid: enterprise-SB-partner1-PA
-  selfoperatorid: enterprise
-  federator:
-    federationid: partner1-PA-enterprise-SB
-    operatorid: partner1
-    countrycode: PA
-    federationaddr: 127.0.0.1:9808
-    mcc: "123"
-    mnc:
-    - "111"
-    - "222"
-    - "333"
-- name: enterprise-SB-partner2-PS-fed
-  selffederationid: enterprise-SB-partner2-PS
-  selfoperatorid: enterprise
-  federator:
-    federationid: partner2-PS-enterprise-SB
-    operatorid: partner2
-    countrycode: PS
-    federationaddr: 127.0.0.1:9809
-    mcc: "123"
-    mnc:
-    - "111"
-    - "222"
-    - "333"
 - name: dmuus-SA-partner1-PA-fed
   selffederationid: dmuus-SA-partner1-PA
   selfoperatorid: dmuus
@@ -109,6 +57,58 @@ federations:
   selfoperatorid: dmuus
   federator:
     federationid: partner2-PS-dmuus-SB
+    operatorid: partner2
+    countrycode: PS
+    federationaddr: 127.0.0.1:9809
+    mcc: "123"
+    mnc:
+    - "111"
+    - "222"
+    - "333"
+- name: enterprise-SA-partner1-PA-fed
+  selffederationid: enterprise-SA-partner1-PA
+  selfoperatorid: enterprise
+  federator:
+    federationid: partner1-PA-enterprise-SA
+    operatorid: partner1
+    countrycode: PA
+    federationaddr: 127.0.0.1:9808
+    mcc: "123"
+    mnc:
+    - "111"
+    - "222"
+    - "333"
+- name: enterprise-SA-partner2-PS-fed
+  selffederationid: enterprise-SA-partner2-PS
+  selfoperatorid: enterprise
+  federator:
+    federationid: partner2-PS-enterprise-SA
+    operatorid: partner2
+    countrycode: PS
+    federationaddr: 127.0.0.1:9809
+    mcc: "123"
+    mnc:
+    - "111"
+    - "222"
+    - "333"
+- name: enterprise-SB-partner1-PA-fed
+  selffederationid: enterprise-SB-partner1-PA
+  selfoperatorid: enterprise
+  federator:
+    federationid: partner1-PA-enterprise-SB
+    operatorid: partner1
+    countrycode: PA
+    federationaddr: 127.0.0.1:9808
+    mcc: "123"
+    mnc:
+    - "111"
+    - "222"
+    - "333"
+- name: enterprise-SB-partner2-PS-fed
+  selffederationid: enterprise-SB-partner2-PS
+  selfoperatorid: enterprise
+  federator:
+    federationid: partner2-PS-enterprise-SB
     operatorid: partner2
     countrycode: PS
     federationaddr: 127.0.0.1:9809

--- a/e2e-tests/data/federation_self_share_zones_show.yml
+++ b/e2e-tests/data/federation_self_share_zones_show.yml
@@ -13,6 +13,30 @@
 # limitations under the License.
 
 federatedselfzones:
+- zoneid: dmuus-cloud-1
+  selfoperatorid: dmuus
+  federationname: dmuus-SA-partner1-PA-fed
+- zoneid: dmuus-cloud-1
+  selfoperatorid: dmuus
+  federationname: dmuus-SA-partner2-PS-fed
+- zoneid: dmuus-cloud-2
+  selfoperatorid: dmuus
+  federationname: dmuus-SA-partner1-PA-fed
+- zoneid: dmuus-cloud-2
+  selfoperatorid: dmuus
+  federationname: dmuus-SA-partner2-PS-fed
+- zoneid: dmuus-cloud-3
+  selfoperatorid: dmuus
+  federationname: dmuus-SB-partner1-PA-fed
+- zoneid: dmuus-cloud-3
+  selfoperatorid: dmuus
+  federationname: dmuus-SB-partner2-PS-fed
+- zoneid: dmuus-cloud-4
+  selfoperatorid: dmuus
+  federationname: dmuus-SB-partner1-PA-fed
+- zoneid: dmuus-cloud-4
+  selfoperatorid: dmuus
+  federationname: dmuus-SB-partner2-PS-fed
 - zoneid: enterprise-1
   selfoperatorid: enterprise
   federationname: enterprise-SA-partner1-PA-fed
@@ -25,27 +49,3 @@ federatedselfzones:
 - zoneid: enterprise-2
   selfoperatorid: enterprise
   federationname: enterprise-SB-partner2-PS-fed
-- zoneid: dmuus-cloud-1
-  selfoperatorid: dmuus
-  federationname: dmuus-SA-partner1-PA-fed
-- zoneid: dmuus-cloud-1
-  selfoperatorid: dmuus
-  federationname: dmuus-SA-partner2-PS-fed
-- zoneid: dmuus-cloud-2
-  selfoperatorid: dmuus
-  federationname: dmuus-SA-partner1-PA-fed
-- zoneid: dmuus-cloud-2
-  selfoperatorid: dmuus
-  federationname: dmuus-SA-partner2-PS-fed
-- zoneid: dmuus-cloud-3
-  selfoperatorid: dmuus
-  federationname: dmuus-SB-partner1-PA-fed
-- zoneid: dmuus-cloud-3
-  selfoperatorid: dmuus
-  federationname: dmuus-SB-partner2-PS-fed
-- zoneid: dmuus-cloud-4
-  selfoperatorid: dmuus
-  federationname: dmuus-SB-partner1-PA-fed
-- zoneid: dmuus-cloud-4
-  selfoperatorid: dmuus
-  federationname: dmuus-SB-partner2-PS-fed

--- a/e2e-tests/data/federation_self_zones.yml
+++ b/e2e-tests/data/federation_self_zones.yml
@@ -13,20 +13,6 @@
 # limitations under the License.
 
 federatorzones:
-- zoneid: enterprise-1
-  operatorid: enterprise
-  countrycode: SA
-  geolocation: 31,-91
-  region: local
-  cloudlets:
-  - enterprise-1
-- zoneid: enterprise-2
-  operatorid: enterprise
-  countrycode: SB
-  geolocation: 31,-91
-  region: locala
-  cloudlets:
-  - enterprise-2
 - zoneid: dmuus-cloud-1
   operatorid: dmuus
   countrycode: SA
@@ -55,3 +41,17 @@ federatorzones:
   region: locala
   cloudlets:
   - dmuus-cloud-4
+- zoneid: enterprise-1
+  operatorid: enterprise
+  countrycode: SA
+  geolocation: 31,-91
+  region: local
+  cloudlets:
+  - enterprise-1
+- zoneid: enterprise-2
+  operatorid: enterprise
+  countrycode: SB
+  geolocation: 31,-91
+  region: locala
+  cloudlets:
+  - enterprise-2

--- a/e2e-tests/data/mc_admin_all_data_show.yml
+++ b/e2e-tests/data/mc_admin_all_data_show.yml
@@ -47,6 +47,10 @@ orgs:
   type: operator
   address: amazon jungle
   phone: 123-123-1234
+- name: dmuus
+  type: operator
+  address: dmuus headquarters
+  phone: 123-123-1234
 - name: enterprise
   type: operator
   address: enterprise headquarters
@@ -54,10 +58,6 @@ orgs:
 - name: gcp
   type: operator
   address: mountain view
-  phone: 123-123-1234
-- name: dmuus
-  type: operator
-  address: dmuus headquarters
   phone: 123-123-1234
 - name: user3org
   type: developer
@@ -76,13 +76,13 @@ roles:
 - org: azure
   username: user1
   role: OperatorManager
+- org: dmuus
+  username: user1
+  role: OperatorManager
 - org: enterprise
   username: user1
   role: OperatorManager
 - org: gcp
-  username: user1
-  role: OperatorManager
-- org: dmuus
   username: user1
   role: OperatorManager
 - org: user3org
@@ -163,14 +163,14 @@ regiondata:
       organization: dmuus
     gpudrivers:
     - key:
-        name: gpu-driver-global
-      storagebucketname: mobiledgex-dev-gpu-drivers
-      licenseconfigstoragepath: local/MobiledgeX/gpu-driver-global/licenseconfig/license.conf
-    - key:
         name: gpu-driver-dmuus-1
         organization: dmuus
       storagebucketname: mobiledgex-dev-gpu-drivers
       licenseconfigstoragepath: local/dmuus/gpu-driver-dmuus-1/licenseconfig/license.conf
+    - key:
+        name: gpu-driver-global
+      storagebucketname: mobiledgex-dev-gpu-drivers
+      licenseconfigstoragepath: local/MobiledgeX/gpu-driver-global/licenseconfig/license.conf
     cloudlets:
     - key:
         organization: azure
@@ -194,42 +194,6 @@ regiondata:
       dnslabel: azure-cloud-4-azure
       rootlbfqdn: shared.azure-cloud-4-azure.local.mobiledgex.net
       licenseconfigstoragepath: local/MobiledgeX/gpu-driver-global/cloudlet/licenseconfig/azure/azure-cloud-4/license.conf
-    - key:
-        organization: enterprise
-        name: enterprise-1
-      location:
-        latitude: 31
-        longitude: -91
-      ipsupport: Dynamic
-      numdynamicips: 254
-      state: Ready
-      flavor:
-        name: x1.small
-      physicalname: enterprise-1
-      containerversion: "2019-10-24"
-      deployment: docker
-      trustpolicystate: NotPresent
-      defaultresourcealertthreshold: 80
-      dnslabel: enterprise-1-enterprise
-      rootlbfqdn: shared.enterprise-1-enterprise.local.mobiledgex.net
-    - key:
-        organization: gcp
-        name: gcp-cloud-5
-      location:
-        latitude: 36
-        longitude: -95
-      ipsupport: Dynamic
-      numdynamicips: 254
-      state: Ready
-      flavor:
-        name: DefaultPlatformFlavor
-      physicalname: gcp-cloud-5
-      containerversion: "2019-10-24"
-      deployment: docker
-      trustpolicystate: NotPresent
-      defaultresourcealertthreshold: 80
-      dnslabel: gcp-cloud-5-gcp
-      rootlbfqdn: shared.gcp-cloud-5-gcp.local.mobiledgex.net
     - key:
         organization: dmuus
         name: dmuus-cloud-1
@@ -284,102 +248,46 @@ regiondata:
       defaultresourcealertthreshold: 80
       dnslabel: dmuus-cloud-2-dmuus
       rootlbfqdn: shared.dmuus-cloud-2-dmuus.local.mobiledgex.net
+    - key:
+        organization: enterprise
+        name: enterprise-1
+      location:
+        latitude: 31
+        longitude: -91
+      ipsupport: Dynamic
+      numdynamicips: 254
+      state: Ready
+      flavor:
+        name: x1.small
+      physicalname: enterprise-1
+      containerversion: "2019-10-24"
+      deployment: docker
+      trustpolicystate: NotPresent
+      defaultresourcealertthreshold: 80
+      dnslabel: enterprise-1-enterprise
+      rootlbfqdn: shared.enterprise-1-enterprise.local.mobiledgex.net
+    - key:
+        organization: gcp
+        name: gcp-cloud-5
+      location:
+        latitude: 36
+        longitude: -95
+      ipsupport: Dynamic
+      numdynamicips: 254
+      state: Ready
+      flavor:
+        name: DefaultPlatformFlavor
+      physicalname: gcp-cloud-5
+      containerversion: "2019-10-24"
+      deployment: docker
+      trustpolicystate: NotPresent
+      defaultresourcealertthreshold: 80
+      dnslabel: gcp-cloud-5-gcp
+      rootlbfqdn: shared.gcp-cloud-5-gcp.local.mobiledgex.net
     cloudletinfos:
     - key:
         organization: azure
         name: azure-cloud-4
-      state: Ready
-      osmaxram: 40960
-      osmaxvcores: 50
-      osmaxvolgb: 5000
-      flavors:
-      - name: x1.tiny
-        vcpus: 1
-        ram: 1024
-        disk: 20
-      - name: x1.small
-        vcpus: 2
-        ram: 4096
-        disk: 40
-      containerversion: "2019-10-24"
-      controllercachereceived: true
-      resourcessnapshot:
-        platformvms:
-        - name: fake-platform-vm
-          type: platformvm
-          status: ACTIVE
-          infraflavor: x1.small
-          ipaddresses:
-          - externalip: 10.101.100.10
-        - name: fake-rootlb-vm
-          type: dedicatedrootlb
-          status: ACTIVE
-          infraflavor: x1.small
-          ipaddresses:
-          - externalip: 10.101.100.11
-        info:
-        - name: RAM
-          value: 8192
-          inframaxvalue: 40960
-          units: MB
-        - name: vCPUs
-          value: 4
-          inframaxvalue: 50
-        - name: External IPs
-          value: 1
-          inframaxvalue: 30
-        - name: Instances
-          value: 2
-      trustpolicystate: NotPresent
-    - key:
-        organization: enterprise
-        name: enterprise-1
-      state: Ready
-      osmaxram: 40960
-      osmaxvcores: 50
-      osmaxvolgb: 5000
-      flavors:
-      - name: x1.tiny
-        vcpus: 1
-        ram: 1024
-        disk: 20
-      - name: x1.small
-        vcpus: 2
-        ram: 4096
-        disk: 40
-      containerversion: "2019-10-24"
-      controllercachereceived: true
-      resourcessnapshot:
-        platformvms:
-        - name: fake-platform-vm
-          type: platformvm
-          status: ACTIVE
-          infraflavor: x1.small
-          ipaddresses:
-          - externalip: 10.101.100.10
-        - name: fake-rootlb-vm
-          type: dedicatedrootlb
-          status: ACTIVE
-          infraflavor: x1.small
-          ipaddresses:
-          - externalip: 10.101.100.11
-        info:
-        - name: RAM
-          value: 8192
-          inframaxvalue: 40960
-          units: MB
-        - name: vCPUs
-          value: 4
-          inframaxvalue: 50
-        - name: External IPs
-          value: 1
-          inframaxvalue: 30
-        - name: Instances
-          value: 2
-      trustpolicystate: NotPresent
-    - key:
-        organization: gcp
-        name: gcp-cloud-5
       state: Ready
       osmaxram: 40960
       osmaxvcores: 50
@@ -515,6 +423,98 @@ regiondata:
         - name: Instances
           value: 2
       trustpolicystate: NotPresent
+    - key:
+        organization: enterprise
+        name: enterprise-1
+      state: Ready
+      osmaxram: 40960
+      osmaxvcores: 50
+      osmaxvolgb: 5000
+      flavors:
+      - name: x1.tiny
+        vcpus: 1
+        ram: 1024
+        disk: 20
+      - name: x1.small
+        vcpus: 2
+        ram: 4096
+        disk: 40
+      containerversion: "2019-10-24"
+      controllercachereceived: true
+      resourcessnapshot:
+        platformvms:
+        - name: fake-platform-vm
+          type: platformvm
+          status: ACTIVE
+          infraflavor: x1.small
+          ipaddresses:
+          - externalip: 10.101.100.10
+        - name: fake-rootlb-vm
+          type: dedicatedrootlb
+          status: ACTIVE
+          infraflavor: x1.small
+          ipaddresses:
+          - externalip: 10.101.100.11
+        info:
+        - name: RAM
+          value: 8192
+          inframaxvalue: 40960
+          units: MB
+        - name: vCPUs
+          value: 4
+          inframaxvalue: 50
+        - name: External IPs
+          value: 1
+          inframaxvalue: 30
+        - name: Instances
+          value: 2
+      trustpolicystate: NotPresent
+    - key:
+        organization: gcp
+        name: gcp-cloud-5
+      state: Ready
+      osmaxram: 40960
+      osmaxvcores: 50
+      osmaxvolgb: 5000
+      flavors:
+      - name: x1.tiny
+        vcpus: 1
+        ram: 1024
+        disk: 20
+      - name: x1.small
+        vcpus: 2
+        ram: 4096
+        disk: 40
+      containerversion: "2019-10-24"
+      controllercachereceived: true
+      resourcessnapshot:
+        platformvms:
+        - name: fake-platform-vm
+          type: platformvm
+          status: ACTIVE
+          infraflavor: x1.small
+          ipaddresses:
+          - externalip: 10.101.100.10
+        - name: fake-rootlb-vm
+          type: dedicatedrootlb
+          status: ACTIVE
+          infraflavor: x1.small
+          ipaddresses:
+          - externalip: 10.101.100.11
+        info:
+        - name: RAM
+          value: 8192
+          inframaxvalue: 40960
+          units: MB
+        - name: vCPUs
+          value: 4
+          inframaxvalue: 50
+        - name: External IPs
+          value: 1
+          inframaxvalue: 30
+        - name: Instances
+          value: 2
+      trustpolicystate: NotPresent
     cloudletpools:
     - key:
         organization: enterprise
@@ -587,24 +587,6 @@ regiondata:
       organization: dmuus
     cloudlets:
     - key:
-        organization: enterprise
-        name: enterprise-2
-      location:
-        latitude: 31
-        longitude: -91
-      ipsupport: Dynamic
-      numdynamicips: 254
-      state: Ready
-      flavor:
-        name: x1.small
-      physicalname: enterprise-2
-      containerversion: "2019-10-24"
-      deployment: docker
-      trustpolicystate: NotPresent
-      defaultresourcealertthreshold: 80
-      dnslabel: enterprise-2-enterprise
-      rootlbfqdn: shared.enterprise-2-enterprise.locala.mobiledgex.net
-    - key:
         organization: dmuus
         name: dmuus-cloud-3
       location:
@@ -640,53 +622,25 @@ regiondata:
       defaultresourcealertthreshold: 80
       dnslabel: dmuus-cloud-4-dmuus
       rootlbfqdn: shared.dmuus-cloud-4-dmuus.locala.mobiledgex.net
-    cloudletinfos:
     - key:
         organization: enterprise
         name: enterprise-2
+      location:
+        latitude: 31
+        longitude: -91
+      ipsupport: Dynamic
+      numdynamicips: 254
       state: Ready
-      osmaxram: 40960
-      osmaxvcores: 50
-      osmaxvolgb: 5000
-      flavors:
-      - name: x1.tiny
-        vcpus: 1
-        ram: 1024
-        disk: 20
-      - name: x1.small
-        vcpus: 2
-        ram: 4096
-        disk: 40
+      flavor:
+        name: x1.small
+      physicalname: enterprise-2
       containerversion: "2019-10-24"
-      controllercachereceived: true
-      resourcessnapshot:
-        platformvms:
-        - name: fake-platform-vm
-          type: platformvm
-          status: ACTIVE
-          infraflavor: x1.small
-          ipaddresses:
-          - externalip: 10.101.100.10
-        - name: fake-rootlb-vm
-          type: dedicatedrootlb
-          status: ACTIVE
-          infraflavor: x1.small
-          ipaddresses:
-          - externalip: 10.101.100.11
-        info:
-        - name: RAM
-          value: 8192
-          inframaxvalue: 40960
-          units: MB
-        - name: vCPUs
-          value: 4
-          inframaxvalue: 50
-        - name: External IPs
-          value: 1
-          inframaxvalue: 30
-        - name: Instances
-          value: 2
+      deployment: docker
       trustpolicystate: NotPresent
+      defaultresourcealertthreshold: 80
+      dnslabel: enterprise-2-enterprise
+      rootlbfqdn: shared.enterprise-2-enterprise.locala.mobiledgex.net
+    cloudletinfos:
     - key:
         organization: dmuus
         name: dmuus-cloud-3
@@ -736,6 +690,52 @@ regiondata:
     - key:
         organization: dmuus
         name: dmuus-cloud-4
+      state: Ready
+      osmaxram: 40960
+      osmaxvcores: 50
+      osmaxvolgb: 5000
+      flavors:
+      - name: x1.tiny
+        vcpus: 1
+        ram: 1024
+        disk: 20
+      - name: x1.small
+        vcpus: 2
+        ram: 4096
+        disk: 40
+      containerversion: "2019-10-24"
+      controllercachereceived: true
+      resourcessnapshot:
+        platformvms:
+        - name: fake-platform-vm
+          type: platformvm
+          status: ACTIVE
+          infraflavor: x1.small
+          ipaddresses:
+          - externalip: 10.101.100.10
+        - name: fake-rootlb-vm
+          type: dedicatedrootlb
+          status: ACTIVE
+          infraflavor: x1.small
+          ipaddresses:
+          - externalip: 10.101.100.11
+        info:
+        - name: RAM
+          value: 8192
+          inframaxvalue: 40960
+          units: MB
+        - name: vCPUs
+          value: 4
+          inframaxvalue: 50
+        - name: External IPs
+          value: 1
+          inframaxvalue: 30
+        - name: Instances
+          value: 2
+      trustpolicystate: NotPresent
+    - key:
+        organization: enterprise
+        name: enterprise-2
       state: Ready
       osmaxram: 40960
       osmaxvcores: 50

--- a/e2e-tests/data/mc_admin_eventsshow_exp.yml
+++ b/e2e-tests/data/mc_admin_eventsshow_exp.yml
@@ -30,14 +30,14 @@
       app: autoprovHA
       apporg: AcmeAppCo
       appver: "1.0"
-      cloudlet: dmuus-cloud-1
-      cloudletorg: dmuus
+      cloudlet: gcp-cloud-5
+      cloudletorg: gcp
       cluster: autocluster-autoprov
       clusterorg: MobiledgeX
       federatedorg: ""
       hostname: ""
       lineno: ""
-      realcluster: Reservable1
+      realcluster: Reservable4
       spanid: ""
       traceid: ""
   - name: Free ClusterInst reservation
@@ -49,14 +49,14 @@
       app: autoprovHA
       apporg: AcmeAppCo
       appver: "1.0"
-      cloudlet: gcp-cloud-5
-      cloudletorg: gcp
+      cloudlet: dmuus-cloud-1
+      cloudletorg: dmuus
       cluster: autocluster-autoprov
       clusterorg: MobiledgeX
       federatedorg: ""
       hostname: ""
       lineno: ""
-      realcluster: Reservable4
+      realcluster: Reservable1
       spanid: ""
       traceid: ""
   - name: Free ClusterInst reservation
@@ -313,14 +313,14 @@
       app: autoprovHA
       apporg: AcmeAppCo
       appver: "1.0"
-      cloudlet: dmuus-cloud-1
-      cloudletorg: dmuus
+      cloudlet: gcp-cloud-5
+      cloudletorg: gcp
       cluster: autocluster-autoprov
       clusterorg: MobiledgeX
       federatedorg: ""
       hostname: ""
       lineno: ""
-      realcluster: Reservable1
+      realcluster: Reservable4
       spanid: ""
       traceid: ""
   - name: Free ClusterInst reservation
@@ -332,14 +332,14 @@
       app: autoprovHA
       apporg: AcmeAppCo
       appver: "1.0"
-      cloudlet: gcp-cloud-5
-      cloudletorg: gcp
+      cloudlet: dmuus-cloud-1
+      cloudletorg: dmuus
       cluster: autocluster-autoprov
       clusterorg: MobiledgeX
       federatedorg: ""
       hostname: ""
       lineno: ""
-      realcluster: Reservable4
+      realcluster: Reservable1
       spanid: ""
       traceid: ""
 - search:

--- a/e2e-tests/data/mc_admin_eventsterms_exp.yml
+++ b/e2e-tests/data/mc_admin_eventsterms_exp.yml
@@ -67,11 +67,11 @@
     - {}
     - key: AcmeAppCo
     - key: MobiledgeX
-    - key: platos
     - key: azure
+    - key: dmuus
     - key: enterprise
     - key: gcp
-    - key: dmuus
+    - key: platos
     - key: user3org
     types:
     - key: audit

--- a/e2e-tests/data/mc_dumpcloudletpools_output.yml
+++ b/e2e-tests/data/mc_dumpcloudletpools_output.yml
@@ -63,27 +63,6 @@ requests:
   - node:
       type: crm
       cloudletkey:
-        organization: enterprise
-        name: enterprise-1
-      region: local
-    output: '{"{\"organization\":\"enterprise\",\"name\":\"enterprise-1\"}":{"{\"organization\":\"enterprise\",\"name\":\"enterprise-pool\"}":{}}}'
-  - node:
-      type: crm
-      cloudletkey:
-        organization: enterprise
-        name: enterprise-2
-      region: locala
-    output: '{"{\"organization\":\"enterprise\",\"name\":\"enterprise-2\"}":{"{\"organization\":\"enterprise\",\"name\":\"enterprise-pool\"}":{}}}'
-  - node:
-      type: crm
-      cloudletkey:
-        organization: gcp
-        name: gcp-cloud-5
-      region: local
-    output: '{"{\"organization\":\"enterprise\",\"name\":\"enterprise-1\"}":{"{\"organization\":\"enterprise\",\"name\":\"enterprise-pool\"}":{}}}'
-  - node:
-      type: crm
-      cloudletkey:
         organization: dmuus
         name: dmuus-cloud-1
       region: local
@@ -109,6 +88,27 @@ requests:
         name: dmuus-cloud-4
       region: locala
     output: '{"{\"organization\":\"enterprise\",\"name\":\"enterprise-2\"}":{"{\"organization\":\"enterprise\",\"name\":\"enterprise-pool\"}":{}}}'
+  - node:
+      type: crm
+      cloudletkey:
+        organization: enterprise
+        name: enterprise-1
+      region: local
+    output: '{"{\"organization\":\"enterprise\",\"name\":\"enterprise-1\"}":{"{\"organization\":\"enterprise\",\"name\":\"enterprise-pool\"}":{}}}'
+  - node:
+      type: crm
+      cloudletkey:
+        organization: enterprise
+        name: enterprise-2
+      region: locala
+    output: '{"{\"organization\":\"enterprise\",\"name\":\"enterprise-2\"}":{"{\"organization\":\"enterprise\",\"name\":\"enterprise-pool\"}":{}}}'
+  - node:
+      type: crm
+      cloudletkey:
+        organization: gcp
+        name: gcp-cloud-5
+      region: local
+    output: '{"{\"organization\":\"enterprise\",\"name\":\"enterprise-1\"}":{"{\"organization\":\"enterprise\",\"name\":\"enterprise-pool\"}":{}}}'
   - node:
       type: dme
       cloudletkey:

--- a/e2e-tests/data/mc_enabledebug_output.yml
+++ b/e2e-tests/data/mc_enabledebug_output.yml
@@ -63,27 +63,6 @@ requests:
   - node:
       type: crm
       cloudletkey:
-        organization: enterprise
-        name: enterprise-1
-      region: local
-    output: api,notify,infra,metrics,upgrade,info,sampled
-  - node:
-      type: crm
-      cloudletkey:
-        organization: enterprise
-        name: enterprise-2
-      region: locala
-    output: api,notify,infra,metrics,upgrade,info,sampled
-  - node:
-      type: crm
-      cloudletkey:
-        organization: gcp
-        name: gcp-cloud-5
-      region: local
-    output: api,notify,infra,metrics,upgrade,info,sampled
-  - node:
-      type: crm
-      cloudletkey:
         organization: dmuus
         name: dmuus-cloud-1
       region: local
@@ -108,6 +87,27 @@ requests:
         organization: dmuus
         name: dmuus-cloud-4
       region: locala
+    output: api,notify,infra,metrics,upgrade,info,sampled
+  - node:
+      type: crm
+      cloudletkey:
+        organization: enterprise
+        name: enterprise-1
+      region: local
+    output: api,notify,infra,metrics,upgrade,info,sampled
+  - node:
+      type: crm
+      cloudletkey:
+        organization: enterprise
+        name: enterprise-2
+      region: locala
+    output: api,notify,infra,metrics,upgrade,info,sampled
+  - node:
+      type: crm
+      cloudletkey:
+        organization: gcp
+        name: gcp-cloud-5
+      region: local
     output: api,notify,infra,metrics,upgrade,info,sampled
   - node:
       type: dme

--- a/e2e-tests/data/mc_orgsinuse_error.yml
+++ b/e2e-tests/data/mc_orgsinuse_error.yml
@@ -42,5 +42,5 @@ errors:
     Cloudlet, ClusterInst'
 - desc: DeleteOrg[6]
   status: 400
-  err: 'Organization platos in use or check failed: region local: in use by some
-    App; region locala: in use by some App'
+  err: 'Organization platos in use or check failed: region local: in use by some App;
+    region locala: in use by some App'

--- a/e2e-tests/data/mc_showdebug_output.yml
+++ b/e2e-tests/data/mc_showdebug_output.yml
@@ -63,27 +63,6 @@ requests:
   - node:
       type: crm
       cloudletkey:
-        organization: enterprise
-        name: enterprise-1
-      region: local
-    output: api,notify,infra,info
-  - node:
-      type: crm
-      cloudletkey:
-        organization: enterprise
-        name: enterprise-2
-      region: locala
-    output: api,notify,infra,info
-  - node:
-      type: crm
-      cloudletkey:
-        organization: gcp
-        name: gcp-cloud-5
-      region: local
-    output: api,notify,infra,info
-  - node:
-      type: crm
-      cloudletkey:
         organization: dmuus
         name: dmuus-cloud-1
       region: local
@@ -108,6 +87,27 @@ requests:
         organization: dmuus
         name: dmuus-cloud-4
       region: locala
+    output: api,notify,infra,info
+  - node:
+      type: crm
+      cloudletkey:
+        organization: enterprise
+        name: enterprise-1
+      region: local
+    output: api,notify,infra,info
+  - node:
+      type: crm
+      cloudletkey:
+        organization: enterprise
+        name: enterprise-2
+      region: locala
+    output: api,notify,infra,info
+  - node:
+      type: crm
+      cloudletkey:
+        organization: gcp
+        name: gcp-cloud-5
+      region: local
     output: api,notify,infra,info
   - node:
       type: dme

--- a/e2e-tests/data/mc_shownode.yml
+++ b/e2e-tests/data/mc_shownode.yml
@@ -108,30 +108,6 @@ nodes:
 - key:
     type: crm
     cloudletkey:
-      organization: enterprise
-      name: enterprise-1
-    region: local
-  containerversion: "2019-10-24"
-  internalpki: useAccessKey,UseVaultPki
-- key:
-    type: crm
-    cloudletkey:
-      organization: enterprise
-      name: enterprise-2
-    region: locala
-  containerversion: "2019-10-24"
-  internalpki: useAccessKey,UseVaultPki
-- key:
-    type: crm
-    cloudletkey:
-      organization: gcp
-      name: gcp-cloud-5
-    region: local
-  containerversion: "2019-10-24"
-  internalpki: useAccessKey,UseVaultPki
-- key:
-    type: crm
-    cloudletkey:
       organization: dmuus
       name: dmuus-cloud-1
     region: local
@@ -167,6 +143,30 @@ nodes:
   containerversion: "2019-10-24"
   internalpki: useAccessKey,UseVaultPki
 - key:
+    type: crm
+    cloudletkey:
+      organization: enterprise
+      name: enterprise-1
+    region: local
+  containerversion: "2019-10-24"
+  internalpki: useAccessKey,UseVaultPki
+- key:
+    type: crm
+    cloudletkey:
+      organization: enterprise
+      name: enterprise-2
+    region: locala
+  containerversion: "2019-10-24"
+  internalpki: useAccessKey,UseVaultPki
+- key:
+    type: crm
+    cloudletkey:
+      organization: gcp
+      name: gcp-cloud-5
+    region: local
+  containerversion: "2019-10-24"
+  internalpki: useAccessKey,UseVaultPki
+- key:
     type: dme
     cloudletkey:
       organization: dmuus
@@ -178,10 +178,10 @@ nodes:
     EdgeEventsBuildDate: ""
     EdgeEventsBuildHead: ""
     EdgeEventsBuildMaster: ""
-    GDDTOperatorBuildAuthor: ""
-    GDDTOperatorBuildDate: ""
-    GDDTOperatorBuildHead: ""
-    GDDTOperatorBuildMaster: ""
+    OPERALPHAOperatorBuildAuthor: ""
+    OPERALPHAOperatorBuildDate: ""
+    OPERALPHAOperatorBuildHead: ""
+    OPERALPHAOperatorBuildMaster: ""
 - key:
     type: dme
     cloudletkey:
@@ -194,10 +194,10 @@ nodes:
     EdgeEventsBuildDate: ""
     EdgeEventsBuildHead: ""
     EdgeEventsBuildMaster: ""
-    GDDTOperatorBuildAuthor: ""
-    GDDTOperatorBuildDate: ""
-    GDDTOperatorBuildHead: ""
-    GDDTOperatorBuildMaster: ""
+    OPERALPHAOperatorBuildAuthor: ""
+    OPERALPHAOperatorBuildDate: ""
+    OPERALPHAOperatorBuildHead: ""
+    OPERALPHAOperatorBuildMaster: ""
 - key:
     type: dme
     cloudletkey:
@@ -210,10 +210,10 @@ nodes:
     EdgeEventsBuildDate: ""
     EdgeEventsBuildHead: ""
     EdgeEventsBuildMaster: ""
-    GDDTOperatorBuildAuthor: ""
-    GDDTOperatorBuildDate: ""
-    GDDTOperatorBuildHead: ""
-    GDDTOperatorBuildMaster: ""
+    OPERALPHAOperatorBuildAuthor: ""
+    OPERALPHAOperatorBuildDate: ""
+    OPERALPHAOperatorBuildHead: ""
+    OPERALPHAOperatorBuildMaster: ""
 - key:
     type: dme
     cloudletkey:
@@ -226,10 +226,10 @@ nodes:
     EdgeEventsBuildDate: ""
     EdgeEventsBuildHead: ""
     EdgeEventsBuildMaster: ""
-    GDDTOperatorBuildAuthor: ""
-    GDDTOperatorBuildDate: ""
-    GDDTOperatorBuildHead: ""
-    GDDTOperatorBuildMaster: ""
+    OPERALPHAOperatorBuildAuthor: ""
+    OPERALPHAOperatorBuildDate: ""
+    OPERALPHAOperatorBuildHead: ""
+    OPERALPHAOperatorBuildMaster: ""
 - key:
     type: frm
     region: local

--- a/e2e-tests/data/mc_spansshow_exp.yml
+++ b/e2e-tests/data/mc_spansshow_exp.yml
@@ -84,9 +84,9 @@
     - msg: search AutoProvPolicy list
       keyvalues:
         carrier: dmuus
-        list: '[key:<organization:"dmuus" name:"dmuus-cloud-1" > loc:<latitude:31 longitude:-91
-          >  key:<organization:"dmuus" name:"dmuus-cloud-2" > loc:<latitude:35 longitude:-95
-          > ]'
+        list: '[key:<organization:"dmuus" name:"dmuus-cloud-1" > loc:<latitude:31
+          longitude:-91 >  key:<organization:"dmuus" name:"dmuus-cloud-2" > loc:<latitude:35
+          longitude:-95 > ]'
         policy: autoprov1
     - msg: search policySearch result
       keyvalues:
@@ -104,7 +104,7 @@
         num-potential-policies: "1"
     - msg: autoprovstats increment
       keyvalues:
-        idx: "7"
+        idx: "8"
         key: '{{AcmeAppCo autoprovapp 1.0} {dmuus dmuus-cloud-2 }}'
         policy: '&{autoprov1 3 3 map[dmuus:[key:<organization:"dmuus" name:"dmuus-cloud-1"
           > loc:<latitude:31 longitude:-91 >  key:<organization:"dmuus" name:"dmuus-cloud-2"

--- a/e2e-tests/data/mc_user1_data_show.yml
+++ b/e2e-tests/data/mc_user1_data_show.yml
@@ -20,6 +20,10 @@ orgs:
   type: operator
   address: amazon jungle
   phone: 123-123-1234
+- name: dmuus
+  type: operator
+  address: dmuus headquarters
+  phone: 123-123-1234
 - name: enterprise
   type: operator
   address: enterprise headquarters
@@ -28,21 +32,17 @@ orgs:
   type: operator
   address: mountain view
   phone: 123-123-1234
-- name: dmuus
-  type: operator
-  address: dmuus headquarters
-  phone: 123-123-1234
 roles:
 - org: azure
+  username: user1
+  role: OperatorManager
+- org: dmuus
   username: user1
   role: OperatorManager
 - org: enterprise
   username: user1
   role: OperatorManager
 - org: gcp
-  username: user1
-  role: OperatorManager
-- org: dmuus
   username: user1
   role: OperatorManager
 cloudletpoolaccessinvitations:
@@ -78,10 +78,10 @@ regiondata:
       organization: dmuus
     gpudrivers:
     - key:
-        name: gpu-driver-global
-    - key:
         name: gpu-driver-dmuus-1
         organization: dmuus
+    - key:
+        name: gpu-driver-global
     cloudlets:
     - key:
         organization: azure
@@ -105,42 +105,6 @@ regiondata:
       dnslabel: azure-cloud-4-azure
       rootlbfqdn: shared.azure-cloud-4-azure.local.mobiledgex.net
       licenseconfigstoragepath: local/MobiledgeX/gpu-driver-global/cloudlet/licenseconfig/azure/azure-cloud-4/license.conf
-    - key:
-        organization: enterprise
-        name: enterprise-1
-      location:
-        latitude: 31
-        longitude: -91
-      ipsupport: Dynamic
-      numdynamicips: 254
-      state: Ready
-      flavor:
-        name: x1.small
-      physicalname: enterprise-1
-      containerversion: "2019-10-24"
-      deployment: docker
-      trustpolicystate: NotPresent
-      defaultresourcealertthreshold: 80
-      dnslabel: enterprise-1-enterprise
-      rootlbfqdn: shared.enterprise-1-enterprise.local.mobiledgex.net
-    - key:
-        organization: gcp
-        name: gcp-cloud-5
-      location:
-        latitude: 36
-        longitude: -95
-      ipsupport: Dynamic
-      numdynamicips: 254
-      state: Ready
-      flavor:
-        name: DefaultPlatformFlavor
-      physicalname: gcp-cloud-5
-      containerversion: "2019-10-24"
-      deployment: docker
-      trustpolicystate: NotPresent
-      defaultresourcealertthreshold: 80
-      dnslabel: gcp-cloud-5-gcp
-      rootlbfqdn: shared.gcp-cloud-5-gcp.local.mobiledgex.net
     - key:
         organization: dmuus
         name: dmuus-cloud-1
@@ -195,48 +159,46 @@ regiondata:
       defaultresourcealertthreshold: 80
       dnslabel: dmuus-cloud-2-dmuus
       rootlbfqdn: shared.dmuus-cloud-2-dmuus.local.mobiledgex.net
+    - key:
+        organization: enterprise
+        name: enterprise-1
+      location:
+        latitude: 31
+        longitude: -91
+      ipsupport: Dynamic
+      numdynamicips: 254
+      state: Ready
+      flavor:
+        name: x1.small
+      physicalname: enterprise-1
+      containerversion: "2019-10-24"
+      deployment: docker
+      trustpolicystate: NotPresent
+      defaultresourcealertthreshold: 80
+      dnslabel: enterprise-1-enterprise
+      rootlbfqdn: shared.enterprise-1-enterprise.local.mobiledgex.net
+    - key:
+        organization: gcp
+        name: gcp-cloud-5
+      location:
+        latitude: 36
+        longitude: -95
+      ipsupport: Dynamic
+      numdynamicips: 254
+      state: Ready
+      flavor:
+        name: DefaultPlatformFlavor
+      physicalname: gcp-cloud-5
+      containerversion: "2019-10-24"
+      deployment: docker
+      trustpolicystate: NotPresent
+      defaultresourcealertthreshold: 80
+      dnslabel: gcp-cloud-5-gcp
+      rootlbfqdn: shared.gcp-cloud-5-gcp.local.mobiledgex.net
     cloudletinfos:
     - key:
         organization: azure
         name: azure-cloud-4
-      state: Ready
-      osmaxram: 40960
-      osmaxvcores: 50
-      osmaxvolgb: 5000
-      flavors:
-      - name: x1.tiny
-        vcpus: 1
-        ram: 1024
-        disk: 20
-      - name: x1.small
-        vcpus: 2
-        ram: 4096
-        disk: 40
-      containerversion: "2019-10-24"
-      controllercachereceived: true
-      trustpolicystate: NotPresent
-    - key:
-        organization: enterprise
-        name: enterprise-1
-      state: Ready
-      osmaxram: 40960
-      osmaxvcores: 50
-      osmaxvolgb: 5000
-      flavors:
-      - name: x1.tiny
-        vcpus: 1
-        ram: 1024
-        disk: 20
-      - name: x1.small
-        vcpus: 2
-        ram: 4096
-        disk: 40
-      containerversion: "2019-10-24"
-      controllercachereceived: true
-      trustpolicystate: NotPresent
-    - key:
-        organization: gcp
-        name: gcp-cloud-5
       state: Ready
       osmaxram: 40960
       osmaxvcores: 50
@@ -291,6 +253,44 @@ regiondata:
       containerversion: "2019-10-24"
       controllercachereceived: true
       trustpolicystate: NotPresent
+    - key:
+        organization: enterprise
+        name: enterprise-1
+      state: Ready
+      osmaxram: 40960
+      osmaxvcores: 50
+      osmaxvolgb: 5000
+      flavors:
+      - name: x1.tiny
+        vcpus: 1
+        ram: 1024
+        disk: 20
+      - name: x1.small
+        vcpus: 2
+        ram: 4096
+        disk: 40
+      containerversion: "2019-10-24"
+      controllercachereceived: true
+      trustpolicystate: NotPresent
+    - key:
+        organization: gcp
+        name: gcp-cloud-5
+      state: Ready
+      osmaxram: 40960
+      osmaxvcores: 50
+      osmaxvolgb: 5000
+      flavors:
+      - name: x1.tiny
+        vcpus: 1
+        ram: 1024
+        disk: 20
+      - name: x1.small
+        vcpus: 2
+        ram: 4096
+        disk: 40
+      containerversion: "2019-10-24"
+      controllercachereceived: true
+      trustpolicystate: NotPresent
     cloudletpools:
     - key:
         organization: enterprise
@@ -320,24 +320,6 @@ regiondata:
     - code: "31026"
       organization: dmuus
     cloudlets:
-    - key:
-        organization: enterprise
-        name: enterprise-2
-      location:
-        latitude: 31
-        longitude: -91
-      ipsupport: Dynamic
-      numdynamicips: 254
-      state: Ready
-      flavor:
-        name: x1.small
-      physicalname: enterprise-2
-      containerversion: "2019-10-24"
-      deployment: docker
-      trustpolicystate: NotPresent
-      defaultresourcealertthreshold: 80
-      dnslabel: enterprise-2-enterprise
-      rootlbfqdn: shared.enterprise-2-enterprise.locala.mobiledgex.net
     - key:
         organization: dmuus
         name: dmuus-cloud-3
@@ -374,26 +356,25 @@ regiondata:
       defaultresourcealertthreshold: 80
       dnslabel: dmuus-cloud-4-dmuus
       rootlbfqdn: shared.dmuus-cloud-4-dmuus.locala.mobiledgex.net
-    cloudletinfos:
     - key:
         organization: enterprise
         name: enterprise-2
+      location:
+        latitude: 31
+        longitude: -91
+      ipsupport: Dynamic
+      numdynamicips: 254
       state: Ready
-      osmaxram: 40960
-      osmaxvcores: 50
-      osmaxvolgb: 5000
-      flavors:
-      - name: x1.tiny
-        vcpus: 1
-        ram: 1024
-        disk: 20
-      - name: x1.small
-        vcpus: 2
-        ram: 4096
-        disk: 40
+      flavor:
+        name: x1.small
+      physicalname: enterprise-2
       containerversion: "2019-10-24"
-      controllercachereceived: true
+      deployment: docker
       trustpolicystate: NotPresent
+      defaultresourcealertthreshold: 80
+      dnslabel: enterprise-2-enterprise
+      rootlbfqdn: shared.enterprise-2-enterprise.locala.mobiledgex.net
+    cloudletinfos:
     - key:
         organization: dmuus
         name: dmuus-cloud-3
@@ -416,6 +397,25 @@ regiondata:
     - key:
         organization: dmuus
         name: dmuus-cloud-4
+      state: Ready
+      osmaxram: 40960
+      osmaxvcores: 50
+      osmaxvolgb: 5000
+      flavors:
+      - name: x1.tiny
+        vcpus: 1
+        ram: 1024
+        disk: 20
+      - name: x1.small
+        vcpus: 2
+        ram: 4096
+        disk: 40
+      containerversion: "2019-10-24"
+      controllercachereceived: true
+      trustpolicystate: NotPresent
+    - key:
+        organization: enterprise
+        name: enterprise-2
       state: Ready
       osmaxram: 40960
       osmaxvcores: 50

--- a/e2e-tests/data/mc_user1_federated_data_show.yml
+++ b/e2e-tests/data/mc_user1_federated_data_show.yml
@@ -20,6 +20,10 @@ orgs:
   type: operator
   address: amazon jungle
   phone: 123-123-1234
+- name: dmuus
+  type: operator
+  address: dmuus headquarters
+  phone: 123-123-1234
 - name: enterprise
   type: operator
   address: enterprise headquarters
@@ -28,21 +32,17 @@ orgs:
   type: operator
   address: mountain view
   phone: 123-123-1234
-- name: dmuus
-  type: operator
-  address: dmuus headquarters
-  phone: 123-123-1234
 roles:
 - org: azure
+  username: user1
+  role: OperatorManager
+- org: dmuus
   username: user1
   role: OperatorManager
 - org: enterprise
   username: user1
   role: OperatorManager
 - org: gcp
-  username: user1
-  role: OperatorManager
-- org: dmuus
   username: user1
   role: OperatorManager
 cloudletpoolaccessinvitations:
@@ -78,10 +78,10 @@ regiondata:
       organization: dmuus
     gpudrivers:
     - key:
-        name: gpu-driver-global
-    - key:
         name: gpu-driver-dmuus-1
         organization: dmuus
+    - key:
+        name: gpu-driver-global
     cloudlets:
     - key:
         organization: azure
@@ -105,6 +105,180 @@ regiondata:
       dnslabel: azure-cloud-4-azure
       rootlbfqdn: shared.azure-cloud-4-azure.local.mobiledgex.net
       licenseconfigstoragepath: local/MobiledgeX/gpu-driver-global/cloudlet/licenseconfig/azure/azure-cloud-4/license.conf
+    - key:
+        organization: dmuus
+        name: dmuus-cloud-1
+      location:
+        latitude: 31
+        longitude: -91
+      ipsupport: Dynamic
+      numdynamicips: 254
+      state: Ready
+      platformtype: Fakeinfra
+      flavor:
+        name: DefaultPlatformFlavor
+      physicalname: dmuus-cloud-1
+      envvar:
+        FAKE_RAM_MAX: "409600"
+        FAKE_VCPUS_MAX: "500"
+        foo: bar
+      containerversion: "2019-10-24"
+      deployment: docker
+      trustpolicystate: NotPresent
+      resourcequotas:
+      - name: RAM
+        alertthreshold: 50
+      - name: vCPUs
+        value: 20
+        alertthreshold: 50
+      - name: External IPs
+        alertthreshold: 10
+      defaultresourcealertthreshold: 80
+      gpuconfig:
+        driver:
+          name: gpu-driver-dmuus-1
+          organization: dmuus
+      dnslabel: dmuus-cloud-1-dmuus
+      rootlbfqdn: shared.dmuus-cloud-1-dmuus.local.mobiledgex.net
+      licenseconfigstoragepath: local/dmuus/gpu-driver-dmuus-1/cloudlet/licenseconfig/dmuus-cloud-1/license.conf
+    - key:
+        organization: dmuus
+        name: dmuus-cloud-2
+      location:
+        latitude: 35
+        longitude: -95
+      ipsupport: Dynamic
+      numdynamicips: 254
+      state: Ready
+      flavor:
+        name: DefaultPlatformFlavor
+      physicalname: dmuus-cloud-2
+      containerversion: "2019-10-24"
+      deployment: docker
+      trustpolicystate: NotPresent
+      defaultresourcealertthreshold: 80
+      dnslabel: dmuus-cloud-2-dmuus
+      rootlbfqdn: shared.dmuus-cloud-2-dmuus.local.mobiledgex.net
+    - key:
+        organization: dmuus
+        name: partner1-cloud-1
+        federatedorganization: partner1
+      location:
+        latitude: 31
+        longitude: -91
+      ipsupport: Dynamic
+      numdynamicips: 10
+      state: Ready
+      platformtype: Federation
+      flavor:
+        name: DefaultPlatformFlavor
+      physicalname: partner1-cloud-1
+      deployment: docker
+      crmaccesskeyupgraderequired: true
+      resourcequotas:
+      - name: vCPUs
+        value: 50
+      - name: RAM
+        value: 40960
+      defaultresourcealertthreshold: 80
+      dnslabel: partner1-cloud-1-dmuus
+      rootlbfqdn: shared.partner1-cloud-1-dmuus.local.mobiledgex.net
+      federationconfig:
+        federationname: dmuus-SA-partner1-PA-fed
+        selffederationid: dmuus-SA-partner1-PA
+        partnerfederationid: partner1-PA-dmuus-SA
+        zonecountrycode: PA
+        partnerfederationaddr: 127.0.0.1:9808
+    - key:
+        organization: dmuus
+        name: partner1-cloud-2
+        federatedorganization: partner1
+      location:
+        latitude: 31
+        longitude: -91
+      ipsupport: Dynamic
+      numdynamicips: 10
+      state: Ready
+      platformtype: Federation
+      flavor:
+        name: DefaultPlatformFlavor
+      physicalname: partner1-cloud-2
+      deployment: docker
+      crmaccesskeyupgraderequired: true
+      resourcequotas:
+      - name: vCPUs
+        value: 20
+      - name: RAM
+        value: 40960
+      defaultresourcealertthreshold: 80
+      dnslabel: partner1-cloud-2-dmuus
+      rootlbfqdn: shared.partner1-cloud-2-dmuus.local.mobiledgex.net
+      federationconfig:
+        federationname: dmuus-SA-partner1-PA-fed
+        selffederationid: dmuus-SA-partner1-PA
+        partnerfederationid: partner1-PA-dmuus-SA
+        zonecountrycode: PA
+        partnerfederationaddr: 127.0.0.1:9808
+    - key:
+        organization: dmuus
+        name: partner2-cloud-1
+        federatedorganization: partner2
+      location:
+        latitude: 31
+        longitude: -91
+      ipsupport: Dynamic
+      numdynamicips: 10
+      state: Ready
+      platformtype: Federation
+      flavor:
+        name: DefaultPlatformFlavor
+      physicalname: partner2-cloud-1
+      deployment: docker
+      crmaccesskeyupgraderequired: true
+      resourcequotas:
+      - name: vCPUs
+        value: 50
+      - name: RAM
+        value: 40960
+      defaultresourcealertthreshold: 80
+      dnslabel: partner2-cloud-1-dmuus
+      rootlbfqdn: shared.partner2-cloud-1-dmuus.local.mobiledgex.net
+      federationconfig:
+        federationname: dmuus-SA-partner2-PS-fed
+        selffederationid: dmuus-SA-partner2-PS
+        partnerfederationid: partner2-PS-dmuus-SA
+        zonecountrycode: PS
+        partnerfederationaddr: 127.0.0.1:9809
+    - key:
+        organization: dmuus
+        name: partner2-cloud-2
+        federatedorganization: partner2
+      location:
+        latitude: 31
+        longitude: -91
+      ipsupport: Dynamic
+      numdynamicips: 10
+      state: Ready
+      platformtype: Federation
+      flavor:
+        name: DefaultPlatformFlavor
+      physicalname: partner2-cloud-2
+      deployment: docker
+      crmaccesskeyupgraderequired: true
+      resourcequotas:
+      - name: vCPUs
+        value: 20
+      - name: RAM
+        value: 40960
+      defaultresourcealertthreshold: 80
+      dnslabel: partner2-cloud-2-dmuus
+      rootlbfqdn: shared.partner2-cloud-2-dmuus.local.mobiledgex.net
+      federationconfig:
+        federationname: dmuus-SA-partner2-PS-fed
+        selffederationid: dmuus-SA-partner2-PS
+        partnerfederationid: partner2-PS-dmuus-SA
+        zonecountrycode: PS
+        partnerfederationaddr: 127.0.0.1:9809
     - key:
         organization: enterprise
         name: enterprise-1
@@ -261,180 +435,6 @@ regiondata:
       defaultresourcealertthreshold: 80
       dnslabel: gcp-cloud-5-gcp
       rootlbfqdn: shared.gcp-cloud-5-gcp.local.mobiledgex.net
-    - key:
-        organization: dmuus
-        name: partner1-cloud-1
-        federatedorganization: partner1
-      location:
-        latitude: 31
-        longitude: -91
-      ipsupport: Dynamic
-      numdynamicips: 10
-      state: Ready
-      platformtype: Federation
-      flavor:
-        name: DefaultPlatformFlavor
-      physicalname: partner1-cloud-1
-      deployment: docker
-      crmaccesskeyupgraderequired: true
-      resourcequotas:
-      - name: vCPUs
-        value: 50
-      - name: RAM
-        value: 40960
-      defaultresourcealertthreshold: 80
-      dnslabel: partner1-cloud-1-dmuus
-      rootlbfqdn: shared.partner1-cloud-1-dmuus.local.mobiledgex.net
-      federationconfig:
-        federationname: dmuus-SA-partner1-PA-fed
-        selffederationid: dmuus-SA-partner1-PA
-        partnerfederationid: partner1-PA-dmuus-SA
-        zonecountrycode: PA
-        partnerfederationaddr: 127.0.0.1:9808
-    - key:
-        organization: dmuus
-        name: partner1-cloud-2
-        federatedorganization: partner1
-      location:
-        latitude: 31
-        longitude: -91
-      ipsupport: Dynamic
-      numdynamicips: 10
-      state: Ready
-      platformtype: Federation
-      flavor:
-        name: DefaultPlatformFlavor
-      physicalname: partner1-cloud-2
-      deployment: docker
-      crmaccesskeyupgraderequired: true
-      resourcequotas:
-      - name: vCPUs
-        value: 20
-      - name: RAM
-        value: 40960
-      defaultresourcealertthreshold: 80
-      dnslabel: partner1-cloud-2-dmuus
-      rootlbfqdn: shared.partner1-cloud-2-dmuus.local.mobiledgex.net
-      federationconfig:
-        federationname: dmuus-SA-partner1-PA-fed
-        selffederationid: dmuus-SA-partner1-PA
-        partnerfederationid: partner1-PA-dmuus-SA
-        zonecountrycode: PA
-        partnerfederationaddr: 127.0.0.1:9808
-    - key:
-        organization: dmuus
-        name: partner2-cloud-1
-        federatedorganization: partner2
-      location:
-        latitude: 31
-        longitude: -91
-      ipsupport: Dynamic
-      numdynamicips: 10
-      state: Ready
-      platformtype: Federation
-      flavor:
-        name: DefaultPlatformFlavor
-      physicalname: partner2-cloud-1
-      deployment: docker
-      crmaccesskeyupgraderequired: true
-      resourcequotas:
-      - name: vCPUs
-        value: 50
-      - name: RAM
-        value: 40960
-      defaultresourcealertthreshold: 80
-      dnslabel: partner2-cloud-1-dmuus
-      rootlbfqdn: shared.partner2-cloud-1-dmuus.local.mobiledgex.net
-      federationconfig:
-        federationname: dmuus-SA-partner2-PS-fed
-        selffederationid: dmuus-SA-partner2-PS
-        partnerfederationid: partner2-PS-dmuus-SA
-        zonecountrycode: PS
-        partnerfederationaddr: 127.0.0.1:9809
-    - key:
-        organization: dmuus
-        name: partner2-cloud-2
-        federatedorganization: partner2
-      location:
-        latitude: 31
-        longitude: -91
-      ipsupport: Dynamic
-      numdynamicips: 10
-      state: Ready
-      platformtype: Federation
-      flavor:
-        name: DefaultPlatformFlavor
-      physicalname: partner2-cloud-2
-      deployment: docker
-      crmaccesskeyupgraderequired: true
-      resourcequotas:
-      - name: vCPUs
-        value: 20
-      - name: RAM
-        value: 40960
-      defaultresourcealertthreshold: 80
-      dnslabel: partner2-cloud-2-dmuus
-      rootlbfqdn: shared.partner2-cloud-2-dmuus.local.mobiledgex.net
-      federationconfig:
-        federationname: dmuus-SA-partner2-PS-fed
-        selffederationid: dmuus-SA-partner2-PS
-        partnerfederationid: partner2-PS-dmuus-SA
-        zonecountrycode: PS
-        partnerfederationaddr: 127.0.0.1:9809
-    - key:
-        organization: dmuus
-        name: dmuus-cloud-1
-      location:
-        latitude: 31
-        longitude: -91
-      ipsupport: Dynamic
-      numdynamicips: 254
-      state: Ready
-      platformtype: Fakeinfra
-      flavor:
-        name: DefaultPlatformFlavor
-      physicalname: dmuus-cloud-1
-      envvar:
-        FAKE_RAM_MAX: "409600"
-        FAKE_VCPUS_MAX: "500"
-        foo: bar
-      containerversion: "2019-10-24"
-      deployment: docker
-      trustpolicystate: NotPresent
-      resourcequotas:
-      - name: RAM
-        alertthreshold: 50
-      - name: vCPUs
-        value: 20
-        alertthreshold: 50
-      - name: External IPs
-        alertthreshold: 10
-      defaultresourcealertthreshold: 80
-      gpuconfig:
-        driver:
-          name: gpu-driver-dmuus-1
-          organization: dmuus
-      dnslabel: dmuus-cloud-1-dmuus
-      rootlbfqdn: shared.dmuus-cloud-1-dmuus.local.mobiledgex.net
-      licenseconfigstoragepath: local/dmuus/gpu-driver-dmuus-1/cloudlet/licenseconfig/dmuus-cloud-1/license.conf
-    - key:
-        organization: dmuus
-        name: dmuus-cloud-2
-      location:
-        latitude: 35
-        longitude: -95
-      ipsupport: Dynamic
-      numdynamicips: 254
-      state: Ready
-      flavor:
-        name: DefaultPlatformFlavor
-      physicalname: dmuus-cloud-2
-      containerversion: "2019-10-24"
-      deployment: docker
-      trustpolicystate: NotPresent
-      defaultresourcealertthreshold: 80
-      dnslabel: dmuus-cloud-2-dmuus
-      rootlbfqdn: shared.dmuus-cloud-2-dmuus.local.mobiledgex.net
     cloudletinfos:
     - key:
         organization: azure
@@ -455,6 +455,64 @@ regiondata:
       containerversion: "2019-10-24"
       controllercachereceived: true
       trustpolicystate: NotPresent
+    - key:
+        organization: dmuus
+        name: dmuus-cloud-1
+      state: Ready
+      osmaxram: 409600
+      osmaxvcores: 500
+      osmaxvolgb: 5000
+      flavors:
+      - name: x1.tiny
+        vcpus: 1
+        ram: 1024
+        disk: 20
+      - name: x1.small
+        vcpus: 2
+        ram: 4096
+        disk: 40
+      containerversion: "2019-10-24"
+      controllercachereceived: true
+      trustpolicystate: NotPresent
+    - key:
+        organization: dmuus
+        name: dmuus-cloud-2
+      state: Ready
+      osmaxram: 40960
+      osmaxvcores: 50
+      osmaxvolgb: 5000
+      flavors:
+      - name: x1.tiny
+        vcpus: 1
+        ram: 1024
+        disk: 20
+      - name: x1.small
+        vcpus: 2
+        ram: 4096
+        disk: 40
+      containerversion: "2019-10-24"
+      controllercachereceived: true
+      trustpolicystate: NotPresent
+    - key:
+        organization: dmuus
+        name: partner1-cloud-1
+        federatedorganization: partner1
+      state: Ready
+    - key:
+        organization: dmuus
+        name: partner1-cloud-2
+        federatedorganization: partner1
+      state: Ready
+    - key:
+        organization: dmuus
+        name: partner2-cloud-1
+        federatedorganization: partner2
+      state: Ready
+    - key:
+        organization: dmuus
+        name: partner2-cloud-2
+        federatedorganization: partner2
+      state: Ready
     - key:
         organization: enterprise
         name: enterprise-1
@@ -513,64 +571,6 @@ regiondata:
       containerversion: "2019-10-24"
       controllercachereceived: true
       trustpolicystate: NotPresent
-    - key:
-        organization: dmuus
-        name: partner1-cloud-1
-        federatedorganization: partner1
-      state: Ready
-    - key:
-        organization: dmuus
-        name: partner1-cloud-2
-        federatedorganization: partner1
-      state: Ready
-    - key:
-        organization: dmuus
-        name: partner2-cloud-1
-        federatedorganization: partner2
-      state: Ready
-    - key:
-        organization: dmuus
-        name: partner2-cloud-2
-        federatedorganization: partner2
-      state: Ready
-    - key:
-        organization: dmuus
-        name: dmuus-cloud-1
-      state: Ready
-      osmaxram: 409600
-      osmaxvcores: 500
-      osmaxvolgb: 5000
-      flavors:
-      - name: x1.tiny
-        vcpus: 1
-        ram: 1024
-        disk: 20
-      - name: x1.small
-        vcpus: 2
-        ram: 4096
-        disk: 40
-      containerversion: "2019-10-24"
-      controllercachereceived: true
-      trustpolicystate: NotPresent
-    - key:
-        organization: dmuus
-        name: dmuus-cloud-2
-      state: Ready
-      osmaxram: 40960
-      osmaxvcores: 50
-      osmaxvolgb: 5000
-      flavors:
-      - name: x1.tiny
-        vcpus: 1
-        ram: 1024
-        disk: 20
-      - name: x1.small
-        vcpus: 2
-        ram: 4096
-        disk: 40
-      containerversion: "2019-10-24"
-      controllercachereceived: true
-      trustpolicystate: NotPresent
     cloudletpools:
     - key:
         organization: enterprise
@@ -600,6 +600,162 @@ regiondata:
     - code: "31026"
       organization: dmuus
     cloudlets:
+    - key:
+        organization: dmuus
+        name: dmuus-cloud-3
+      location:
+        latitude: 32
+        longitude: -92
+      ipsupport: Dynamic
+      numdynamicips: 254
+      state: Ready
+      flavor:
+        name: DefaultPlatformFlavor
+      physicalname: dmuus-cloud-3
+      containerversion: "2019-10-24"
+      deployment: docker
+      trustpolicystate: NotPresent
+      defaultresourcealertthreshold: 80
+      dnslabel: dmuus-cloud-3-dmuus
+      rootlbfqdn: shared.dmuus-cloud-3-dmuus.locala.mobiledgex.net
+    - key:
+        organization: dmuus
+        name: dmuus-cloud-4
+      location:
+        latitude: 36
+        longitude: -96
+      ipsupport: Dynamic
+      numdynamicips: 254
+      state: Ready
+      flavor:
+        name: DefaultPlatformFlavor
+      physicalname: dmuus-cloud-4
+      containerversion: "2019-10-24"
+      deployment: docker
+      trustpolicystate: NotPresent
+      defaultresourcealertthreshold: 80
+      dnslabel: dmuus-cloud-4-dmuus
+      rootlbfqdn: shared.dmuus-cloud-4-dmuus.locala.mobiledgex.net
+    - key:
+        organization: dmuus
+        name: partner1-cloud-1
+        federatedorganization: partner1
+      location:
+        latitude: 31
+        longitude: -91
+      ipsupport: Dynamic
+      numdynamicips: 10
+      state: Ready
+      platformtype: Federation
+      flavor:
+        name: DefaultPlatformFlavor
+      physicalname: partner1-cloud-1
+      deployment: docker
+      crmaccesskeyupgraderequired: true
+      resourcequotas:
+      - name: vCPUs
+        value: 50
+      - name: RAM
+        value: 40960
+      defaultresourcealertthreshold: 80
+      dnslabel: partner1-cloud-1-dmuus
+      rootlbfqdn: shared.partner1-cloud-1-dmuus.locala.mobiledgex.net
+      federationconfig:
+        federationname: dmuus-SB-partner1-PA-fed
+        selffederationid: dmuus-SB-partner1-PA
+        partnerfederationid: partner1-PA-dmuus-SB
+        zonecountrycode: PA
+        partnerfederationaddr: 127.0.0.1:9808
+    - key:
+        organization: dmuus
+        name: partner1-cloud-2
+        federatedorganization: partner1
+      location:
+        latitude: 31
+        longitude: -91
+      ipsupport: Dynamic
+      numdynamicips: 10
+      state: Ready
+      platformtype: Federation
+      flavor:
+        name: DefaultPlatformFlavor
+      physicalname: partner1-cloud-2
+      deployment: docker
+      crmaccesskeyupgraderequired: true
+      resourcequotas:
+      - name: vCPUs
+        value: 20
+      - name: RAM
+        value: 40960
+      defaultresourcealertthreshold: 80
+      dnslabel: partner1-cloud-2-dmuus
+      rootlbfqdn: shared.partner1-cloud-2-dmuus.locala.mobiledgex.net
+      federationconfig:
+        federationname: dmuus-SB-partner1-PA-fed
+        selffederationid: dmuus-SB-partner1-PA
+        partnerfederationid: partner1-PA-dmuus-SB
+        zonecountrycode: PA
+        partnerfederationaddr: 127.0.0.1:9808
+    - key:
+        organization: dmuus
+        name: partner2-cloud-1
+        federatedorganization: partner2
+      location:
+        latitude: 31
+        longitude: -91
+      ipsupport: Dynamic
+      numdynamicips: 10
+      state: Ready
+      platformtype: Federation
+      flavor:
+        name: DefaultPlatformFlavor
+      physicalname: partner2-cloud-1
+      deployment: docker
+      crmaccesskeyupgraderequired: true
+      resourcequotas:
+      - name: vCPUs
+        value: 50
+      - name: RAM
+        value: 40960
+      defaultresourcealertthreshold: 80
+      dnslabel: partner2-cloud-1-dmuus
+      rootlbfqdn: shared.partner2-cloud-1-dmuus.locala.mobiledgex.net
+      federationconfig:
+        federationname: dmuus-SB-partner2-PS-fed
+        selffederationid: dmuus-SB-partner2-PS
+        partnerfederationid: partner2-PS-dmuus-SB
+        zonecountrycode: PS
+        partnerfederationaddr: 127.0.0.1:9809
+    - key:
+        organization: dmuus
+        name: partner2-cloud-2
+        federatedorganization: partner2
+      location:
+        latitude: 31
+        longitude: -91
+      ipsupport: Dynamic
+      numdynamicips: 10
+      state: Ready
+      platformtype: Federation
+      flavor:
+        name: DefaultPlatformFlavor
+      physicalname: partner2-cloud-2
+      deployment: docker
+      crmaccesskeyupgraderequired: true
+      resourcequotas:
+      - name: vCPUs
+        value: 20
+      - name: RAM
+        value: 40960
+      defaultresourcealertthreshold: 80
+      dnslabel: partner2-cloud-2-dmuus
+      rootlbfqdn: shared.partner2-cloud-2-dmuus.locala.mobiledgex.net
+      federationconfig:
+        federationname: dmuus-SB-partner2-PS-fed
+        selffederationid: dmuus-SB-partner2-PS
+        partnerfederationid: partner2-PS-dmuus-SB
+        zonecountrycode: PS
+        partnerfederationaddr: 127.0.0.1:9809
     - key:
         organization: enterprise
         name: enterprise-2
@@ -738,163 +894,65 @@ regiondata:
         partnerfederationid: partner2-PS-enterprise-SB
         zonecountrycode: PS
         partnerfederationaddr: 127.0.0.1:9809
+    cloudletinfos:
+    - key:
+        organization: dmuus
+        name: dmuus-cloud-3
+      state: Ready
+      osmaxram: 40960
+      osmaxvcores: 50
+      osmaxvolgb: 5000
+      flavors:
+      - name: x1.tiny
+        vcpus: 1
+        ram: 1024
+        disk: 20
+      - name: x1.small
+        vcpus: 2
+        ram: 4096
+        disk: 40
+      containerversion: "2019-10-24"
+      controllercachereceived: true
+      trustpolicystate: NotPresent
+    - key:
+        organization: dmuus
+        name: dmuus-cloud-4
+      state: Ready
+      osmaxram: 40960
+      osmaxvcores: 50
+      osmaxvolgb: 5000
+      flavors:
+      - name: x1.tiny
+        vcpus: 1
+        ram: 1024
+        disk: 20
+      - name: x1.small
+        vcpus: 2
+        ram: 4096
+        disk: 40
+      containerversion: "2019-10-24"
+      controllercachereceived: true
+      trustpolicystate: NotPresent
     - key:
         organization: dmuus
         name: partner1-cloud-1
         federatedorganization: partner1
-      location:
-        latitude: 31
-        longitude: -91
-      ipsupport: Dynamic
-      numdynamicips: 10
       state: Ready
-      platformtype: Federation
-      flavor:
-        name: DefaultPlatformFlavor
-      physicalname: partner1-cloud-1
-      deployment: docker
-      crmaccesskeyupgraderequired: true
-      resourcequotas:
-      - name: vCPUs
-        value: 50
-      - name: RAM
-        value: 40960
-      defaultresourcealertthreshold: 80
-      dnslabel: partner1-cloud-1-dmuus
-      rootlbfqdn: shared.partner1-cloud-1-dmuus.locala.mobiledgex.net
-      federationconfig:
-        federationname: dmuus-SB-partner1-PA-fed
-        selffederationid: dmuus-SB-partner1-PA
-        partnerfederationid: partner1-PA-dmuus-SB
-        zonecountrycode: PA
-        partnerfederationaddr: 127.0.0.1:9808
     - key:
         organization: dmuus
         name: partner1-cloud-2
         federatedorganization: partner1
-      location:
-        latitude: 31
-        longitude: -91
-      ipsupport: Dynamic
-      numdynamicips: 10
       state: Ready
-      platformtype: Federation
-      flavor:
-        name: DefaultPlatformFlavor
-      physicalname: partner1-cloud-2
-      deployment: docker
-      crmaccesskeyupgraderequired: true
-      resourcequotas:
-      - name: vCPUs
-        value: 20
-      - name: RAM
-        value: 40960
-      defaultresourcealertthreshold: 80
-      dnslabel: partner1-cloud-2-dmuus
-      rootlbfqdn: shared.partner1-cloud-2-dmuus.locala.mobiledgex.net
-      federationconfig:
-        federationname: dmuus-SB-partner1-PA-fed
-        selffederationid: dmuus-SB-partner1-PA
-        partnerfederationid: partner1-PA-dmuus-SB
-        zonecountrycode: PA
-        partnerfederationaddr: 127.0.0.1:9808
     - key:
         organization: dmuus
         name: partner2-cloud-1
         federatedorganization: partner2
-      location:
-        latitude: 31
-        longitude: -91
-      ipsupport: Dynamic
-      numdynamicips: 10
       state: Ready
-      platformtype: Federation
-      flavor:
-        name: DefaultPlatformFlavor
-      physicalname: partner2-cloud-1
-      deployment: docker
-      crmaccesskeyupgraderequired: true
-      resourcequotas:
-      - name: vCPUs
-        value: 50
-      - name: RAM
-        value: 40960
-      defaultresourcealertthreshold: 80
-      dnslabel: partner2-cloud-1-dmuus
-      rootlbfqdn: shared.partner2-cloud-1-dmuus.locala.mobiledgex.net
-      federationconfig:
-        federationname: dmuus-SB-partner2-PS-fed
-        selffederationid: dmuus-SB-partner2-PS
-        partnerfederationid: partner2-PS-dmuus-SB
-        zonecountrycode: PS
-        partnerfederationaddr: 127.0.0.1:9809
     - key:
         organization: dmuus
         name: partner2-cloud-2
         federatedorganization: partner2
-      location:
-        latitude: 31
-        longitude: -91
-      ipsupport: Dynamic
-      numdynamicips: 10
       state: Ready
-      platformtype: Federation
-      flavor:
-        name: DefaultPlatformFlavor
-      physicalname: partner2-cloud-2
-      deployment: docker
-      crmaccesskeyupgraderequired: true
-      resourcequotas:
-      - name: vCPUs
-        value: 20
-      - name: RAM
-        value: 40960
-      defaultresourcealertthreshold: 80
-      dnslabel: partner2-cloud-2-dmuus
-      rootlbfqdn: shared.partner2-cloud-2-dmuus.locala.mobiledgex.net
-      federationconfig:
-        federationname: dmuus-SB-partner2-PS-fed
-        selffederationid: dmuus-SB-partner2-PS
-        partnerfederationid: partner2-PS-dmuus-SB
-        zonecountrycode: PS
-        partnerfederationaddr: 127.0.0.1:9809
-    - key:
-        organization: dmuus
-        name: dmuus-cloud-3
-      location:
-        latitude: 32
-        longitude: -92
-      ipsupport: Dynamic
-      numdynamicips: 254
-      state: Ready
-      flavor:
-        name: DefaultPlatformFlavor
-      physicalname: dmuus-cloud-3
-      containerversion: "2019-10-24"
-      deployment: docker
-      trustpolicystate: NotPresent
-      defaultresourcealertthreshold: 80
-      dnslabel: dmuus-cloud-3-dmuus
-      rootlbfqdn: shared.dmuus-cloud-3-dmuus.locala.mobiledgex.net
-    - key:
-        organization: dmuus
-        name: dmuus-cloud-4
-      location:
-        latitude: 36
-        longitude: -96
-      ipsupport: Dynamic
-      numdynamicips: 254
-      state: Ready
-      flavor:
-        name: DefaultPlatformFlavor
-      physicalname: dmuus-cloud-4
-      containerversion: "2019-10-24"
-      deployment: docker
-      trustpolicystate: NotPresent
-      defaultresourcealertthreshold: 80
-      dnslabel: dmuus-cloud-4-dmuus
-      rootlbfqdn: shared.dmuus-cloud-4-dmuus.locala.mobiledgex.net
-    cloudletinfos:
     - key:
         organization: enterprise
         name: enterprise-2
@@ -934,64 +992,6 @@ regiondata:
         name: partner2-cloud-2
         federatedorganization: partner2
       state: Ready
-    - key:
-        organization: dmuus
-        name: partner1-cloud-1
-        federatedorganization: partner1
-      state: Ready
-    - key:
-        organization: dmuus
-        name: partner1-cloud-2
-        federatedorganization: partner1
-      state: Ready
-    - key:
-        organization: dmuus
-        name: partner2-cloud-1
-        federatedorganization: partner2
-      state: Ready
-    - key:
-        organization: dmuus
-        name: partner2-cloud-2
-        federatedorganization: partner2
-      state: Ready
-    - key:
-        organization: dmuus
-        name: dmuus-cloud-3
-      state: Ready
-      osmaxram: 40960
-      osmaxvcores: 50
-      osmaxvolgb: 5000
-      flavors:
-      - name: x1.tiny
-        vcpus: 1
-        ram: 1024
-        disk: 20
-      - name: x1.small
-        vcpus: 2
-        ram: 4096
-        disk: 40
-      containerversion: "2019-10-24"
-      controllercachereceived: true
-      trustpolicystate: NotPresent
-    - key:
-        organization: dmuus
-        name: dmuus-cloud-4
-      state: Ready
-      osmaxram: 40960
-      osmaxvcores: 50
-      osmaxvolgb: 5000
-      flavors:
-      - name: x1.tiny
-        vcpus: 1
-        ram: 1024
-        disk: 20
-      - name: x1.small
-        vcpus: 2
-        ram: 4096
-        disk: 40
-      containerversion: "2019-10-24"
-      controllercachereceived: true
-      trustpolicystate: NotPresent
     cloudletpools:
     - key:
         organization: enterprise

--- a/e2e-tests/data/mc_user2_data_show.yml
+++ b/e2e-tests/data/mc_user2_data_show.yml
@@ -82,16 +82,6 @@ regiondata:
         driver:
           name: gpu-driver-global
     - key:
-        organization: gcp
-        name: gcp-cloud-5
-      location:
-        latitude: 36
-        longitude: -95
-      ipsupport: Dynamic
-      numdynamicips: 254
-      state: Ready
-      trustpolicystate: NotPresent
-    - key:
         organization: dmuus
         name: dmuus-cloud-1
       location:
@@ -111,6 +101,16 @@ regiondata:
         name: dmuus-cloud-2
       location:
         latitude: 35
+        longitude: -95
+      ipsupport: Dynamic
+      numdynamicips: 254
+      state: Ready
+      trustpolicystate: NotPresent
+    - key:
+        organization: gcp
+        name: gcp-cloud-5
+      location:
+        latitude: 36
         longitude: -95
       ipsupport: Dynamic
       numdynamicips: 254

--- a/e2e-tests/data/mc_user2_eventsshow_exp.yml
+++ b/e2e-tests/data/mc_user2_eventsshow_exp.yml
@@ -102,14 +102,14 @@
       app: autoprovHA
       apporg: AcmeAppCo
       appver: "1.0"
-      cloudlet: dmuus-cloud-1
-      cloudletorg: dmuus
+      cloudlet: gcp-cloud-5
+      cloudletorg: gcp
       cluster: autocluster-autoprov
       clusterorg: MobiledgeX
       federatedorg: ""
       hostname: ""
       lineno: ""
-      realcluster: Reservable1
+      realcluster: Reservable4
       spanid: ""
       traceid: ""
   - name: Free ClusterInst reservation
@@ -121,14 +121,14 @@
       app: autoprovHA
       apporg: AcmeAppCo
       appver: "1.0"
-      cloudlet: gcp-cloud-5
-      cloudletorg: gcp
+      cloudlet: dmuus-cloud-1
+      cloudletorg: dmuus
       cluster: autocluster-autoprov
       clusterorg: MobiledgeX
       federatedorg: ""
       hostname: ""
       lineno: ""
-      realcluster: Reservable4
+      realcluster: Reservable1
       spanid: ""
       traceid: ""
 - search:

--- a/e2e-tests/data/mc_user2_orgeventsshow_exp.yml
+++ b/e2e-tests/data/mc_user2_orgeventsshow_exp.yml
@@ -48,14 +48,14 @@
       app: autoprovHA
       apporg: AcmeAppCo
       appver: "1.0"
-      cloudlet: dmuus-cloud-1
-      cloudletorg: dmuus
+      cloudlet: gcp-cloud-5
+      cloudletorg: gcp
       cluster: autocluster-autoprov
       clusterorg: MobiledgeX
       federatedorg: ""
       hostname: ""
       lineno: ""
-      realcluster: Reservable1
+      realcluster: Reservable4
       spanid: ""
       traceid: ""
   - name: Free ClusterInst reservation
@@ -67,13 +67,13 @@
       app: autoprovHA
       apporg: AcmeAppCo
       appver: "1.0"
-      cloudlet: gcp-cloud-5
-      cloudletorg: gcp
+      cloudlet: dmuus-cloud-1
+      cloudletorg: dmuus
       cluster: autocluster-autoprov
       clusterorg: MobiledgeX
       federatedorg: ""
       hostname: ""
       lineno: ""
-      realcluster: Reservable4
+      realcluster: Reservable1
       spanid: ""
       traceid: ""

--- a/e2e-tests/data/mc_user3_data_show.yml
+++ b/e2e-tests/data/mc_user3_data_show.yml
@@ -98,26 +98,6 @@ regiondata:
         driver:
           name: gpu-driver-global
     - key:
-        organization: enterprise
-        name: enterprise-1
-      location:
-        latitude: 31
-        longitude: -91
-      ipsupport: Dynamic
-      numdynamicips: 254
-      state: Ready
-      trustpolicystate: NotPresent
-    - key:
-        organization: gcp
-        name: gcp-cloud-5
-      location:
-        latitude: 36
-        longitude: -95
-      ipsupport: Dynamic
-      numdynamicips: 254
-      state: Ready
-      trustpolicystate: NotPresent
-    - key:
         organization: dmuus
         name: dmuus-cloud-1
       location:
@@ -137,6 +117,26 @@ regiondata:
         name: dmuus-cloud-2
       location:
         latitude: 35
+        longitude: -95
+      ipsupport: Dynamic
+      numdynamicips: 254
+      state: Ready
+      trustpolicystate: NotPresent
+    - key:
+        organization: enterprise
+        name: enterprise-1
+      location:
+        latitude: 31
+        longitude: -91
+      ipsupport: Dynamic
+      numdynamicips: 254
+      state: Ready
+      trustpolicystate: NotPresent
+    - key:
+        organization: gcp
+        name: gcp-cloud-5
+      location:
+        latitude: 36
         longitude: -95
       ipsupport: Dynamic
       numdynamicips: 254
@@ -341,16 +341,6 @@ regiondata:
       disk: 1
     cloudlets:
     - key:
-        organization: enterprise
-        name: enterprise-2
-      location:
-        latitude: 31
-        longitude: -91
-      ipsupport: Dynamic
-      numdynamicips: 254
-      state: Ready
-      trustpolicystate: NotPresent
-    - key:
         organization: dmuus
         name: dmuus-cloud-3
       location:
@@ -366,6 +356,16 @@ regiondata:
       location:
         latitude: 36
         longitude: -96
+      ipsupport: Dynamic
+      numdynamicips: 254
+      state: Ready
+      trustpolicystate: NotPresent
+    - key:
+        organization: enterprise
+        name: enterprise-2
+      location:
+        latitude: 31
+        longitude: -91
       ipsupport: Dynamic
       numdynamicips: 254
       state: Ready

--- a/e2e-tests/data/mc_user3_empty_show.yml
+++ b/e2e-tests/data/mc_user3_empty_show.yml
@@ -87,16 +87,6 @@ regiondata:
         driver:
           name: gpu-driver-global
     - key:
-        organization: gcp
-        name: gcp-cloud-5
-      location:
-        latitude: 36
-        longitude: -95
-      ipsupport: Dynamic
-      numdynamicips: 254
-      state: Ready
-      trustpolicystate: NotPresent
-    - key:
         organization: dmuus
         name: dmuus-cloud-1
       location:
@@ -116,6 +106,16 @@ regiondata:
         name: dmuus-cloud-2
       location:
         latitude: 35
+        longitude: -95
+      ipsupport: Dynamic
+      numdynamicips: 254
+      state: Ready
+      trustpolicystate: NotPresent
+    - key:
+        organization: gcp
+        name: gcp-cloud-5
+      location:
+        latitude: 36
         longitude: -95
       ipsupport: Dynamic
       numdynamicips: 254

--- a/e2e-tests/int-process/services.go
+++ b/e2e-tests/int-process/services.go
@@ -22,7 +22,6 @@ import (
 	"html/template"
 	"os"
 	"os/exec"
-	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -255,17 +254,17 @@ func StartCloudletPrometheus(ctx context.Context, remoteWriteAddr string, cloudl
 
 	// local container specific options
 	args = append([]string{"run", "--rm"}, args...)
-	if runtime.GOOS != "darwin" {
-		// For Linux, "host.docker.internal" host name doesn't work from inside docker container
-		// Use "--add-host" to add this mapping, only works if Docker version >= 20.04
-		args = append(args, "--add-host", "host.docker.internal:host-gateway")
+	var err error
+	args, err = process.AddHostDockerInternal(args)
+	if err != nil {
+		return err
 	}
 	// set name and image path
 	promImage := PrometheusImagePath + ":" + PrometheusImageVersion
 	args = append(args, []string{"--name", PrometheusContainer, promImage}...)
 	args = append(args, cmdOpts...)
 
-	_, err := process.StartLocal(PrometheusContainer, "docker", args, nil, "/tmp/cloudlet_prometheus.log")
+	_, err = process.StartLocal(PrometheusContainer, "docker", args, nil, "/tmp/cloudlet_prometheus.log")
 	if err != nil {
 		return err
 	}

--- a/e2e-tests/setups/local_multi.yml
+++ b/e2e-tests/setups/local_multi.yml
@@ -42,7 +42,7 @@ toksims:
 
 qossessims:
 - name: qossessim1
-  port: 8081
+  port: 8083
   hostname: "127.0.0.1"
 
 vaults:
@@ -379,7 +379,7 @@ dmes:
   notifyaddrs: "127.0.0.1:37001,127.0.0.1:37002"
   locverurl: "{{locverurl}}"
   toksrvurl: "{{toksrvurl}}"
-  qossesaddr: "http://localhost:8081"
+  qossesaddr: "http://localhost:8083"
   carrier: GDDT
   cloudletkey: '{"organization":"dmuus","name":"dmuus-cloud-1"}'
   vaultaddr: "http://127.0.0.1:8200"
@@ -467,8 +467,8 @@ mcs:
   consoleproxyaddr: "127.0.0.1:6080"
   alertresolvetimeout: "{{alertmgrresolvetimeout}}"
   alertmgrapiaddr: "https://127.0.0.1:9094"
-  apitlscert: "{{tlsoutdir}}/mex-server.crt"
-  apitlskey: "{{tlsoutdir}}/mex-server.key"
+  apitlscert: "{{tlsoutdir}}/test-server.crt"
+  apitlskey: "{{tlsoutdir}}/test-server.key"
   deploymenttag: dev
   envvars:
     ES_SERVER_URLS: https://localhost:9201
@@ -488,8 +488,8 @@ mcs:
   consoleproxyaddr: "127.0.0.1:6081"
   alertmgrapiaddr: "https://127.0.0.1:9094"
   alertresolvetimeout: "{{alertmgrresolvetimeout}}"
-  apitlscert: "{{tlsoutdir}}/mex-server.crt"
-  apitlskey: "{{tlsoutdir}}/mex-server.key"
+  apitlscert: "{{tlsoutdir}}/test-server.crt"
+  apitlskey: "{{tlsoutdir}}/test-server.key"
   deploymenttag: dev
   envvars:
     ES_SERVER_URLS: https://localhost:9201
@@ -505,8 +505,8 @@ mcs:
   ldapaddr: "127.0.0.1:9889"
   federationaddr: "127.0.0.1:9808"
   notifysrvaddr: "127.0.0.1:52081"
-  apitlscert: "{{tlsoutdir}}/mex-server.crt"
-  apitlskey: "{{tlsoutdir}}/mex-server.key"
+  apitlscert: "{{tlsoutdir}}/test-server.crt"
+  apitlskey: "{{tlsoutdir}}/test-server.key"
   deploymenttag: dev
   envvars:
     ES_SERVER_URLS: https://localhost:9201
@@ -522,8 +522,8 @@ mcs:
   ldapaddr: "127.0.0.1:9989"
   federationaddr: "127.0.0.1:9809"
   notifysrvaddr: "127.0.0.1:52091"
-  apitlscert: "{{tlsoutdir}}/mex-server.crt"
-  apitlskey: "{{tlsoutdir}}/mex-server.key"
+  apitlscert: "{{tlsoutdir}}/test-server.crt"
+  apitlskey: "{{tlsoutdir}}/test-server.key"
   deploymenttag: dev
   envvars:
     ES_SERVER_URLS: https://localhost:9201
@@ -565,8 +565,8 @@ nginxproxys:
 - name: es-proxy
   dockernetwork: e2e-logging
   tls:
-    servercert: "{{tlsoutdir}}/mex-server.crt"
-    serverkey: "{{tlsoutdir}}/mex-server.key"
+    servercert: "{{tlsoutdir}}/test-server.crt"
+    serverkey: "{{tlsoutdir}}/test-server.key"
   servers:
   - servername: es-proxy
     tlsport: 9201
@@ -575,8 +575,8 @@ nginxproxys:
 - name: jaeger-proxy
   dockernetwork: e2e-logging
   tls:
-    servercert: "{{tlsoutdir}}/mex-server.crt"
-    serverkey: "{{tlsoutdir}}/mex-server.key"
+    servercert: "{{tlsoutdir}}/test-server.crt"
+    serverkey: "{{tlsoutdir}}/test-server.key"
   servers:
   - servername: jaeger-ui
     port: 16687
@@ -674,8 +674,8 @@ alertmanagersidecars:
   configfile: "/tmp/alertmanager.yml"
   httpaddr: "127.0.0.1:9094"
   tls:
-    servercert: "{{tlsoutdir}}/mex-server.crt"
-    serverkey: "{{tlsoutdir}}/mex-server.key"
+    servercert: "{{tlsoutdir}}/test-server.crt"
+    serverkey: "{{tlsoutdir}}/test-server.key"
     cacert: "/tmp/vault_pki/global.cert.pem"
   localtest: true
   hostname: "127.0.0.1"

--- a/e2e-tests/testfiles/alerttest.yml
+++ b/e2e-tests/testfiles/alerttest.yml
@@ -112,7 +112,7 @@ tests:
 
   - name: verify that email notification about an alert was sent to both admin and user2
     actions: [email-check]
-    retrycount: 10
+    retrycount: 20
     retryintervalsec: 0.5
     compareyaml:
       yaml1: '{{outputdir}}/show-commands.yml'
@@ -139,7 +139,7 @@ tests:
 
   - name: verify that email notification about an alert resolution was sent
     actions: [email-check]
-    retrycount: 10
+    retrycount: 20
     retryintervalsec: 0.5
     compareyaml:
       yaml1: '{{outputdir}}/show-commands.yml'
@@ -205,7 +205,7 @@ tests:
 
   - name: verify that email notification about an alert was sent
     actions: [email-check]
-    retrycount: 10
+    retrycount: 20
     retryintervalsec: 0.5
     compareyaml:
       yaml1: '{{outputdir}}/show-commands.yml'
@@ -251,7 +251,7 @@ tests:
 
   - name: verify that email notification about an alert resolution was sent
     actions: [email-check]
-    retrycount: 10
+    retrycount: 20
     retryintervalsec: 0.5
     compareyaml:
       yaml1: '{{outputdir}}/show-commands.yml'
@@ -354,7 +354,7 @@ tests:
 
   - name: verify that email notification about the cloudlet alert was sent
     actions: [email-check]
-    retrycount: 10
+    retrycount: 20
     retryintervalsec: 0.5
     compareyaml:
       yaml1: '{{outputdir}}/show-commands.yml'
@@ -418,7 +418,7 @@ tests:
 
   - name: verify that email notification about the cloudlet alert was sent
     actions: [email-check]
-    retrycount: 10
+    retrycount: 20
     retryintervalsec: 0.5
     compareyaml:
       yaml1: '{{outputdir}}/show-commands.yml'
@@ -432,7 +432,7 @@ tests:
 
   - name: verify that email notification about the cloudlet alert resolution was sent
     actions: [email-check]
-    retrycount: 10
+    retrycount: 20
     retryintervalsec: 0.5
     compareyaml:
       yaml1: '{{outputdir}}/show-commands.yml'

--- a/mc/orm/server.go
+++ b/mc/orm/server.go
@@ -220,6 +220,7 @@ func RunServer(config *ServerConfig) (retserver *Server, reterr error) {
 	defer span.Finish()
 	defer func() {
 		if reterr != nil {
+			log.SpanLog(ctx, log.DebugLevelApi, "server failed", "err", reterr)
 			server.Stop()
 		}
 	}()

--- a/operator-api-gw/operalpha/operalpha-sessions/sessionsclient/sessionsclient.go
+++ b/operator-api-gw/operalpha/operalpha-sessions/sessionsclient/sessionsclient.go
@@ -30,7 +30,7 @@ import (
 )
 
 func GetApiKeyFromVault(ctx context.Context, vaultConfig *vault.Config) (string, error) {
-	apiKeyPath := "/secret/data/accounts/operalpha/sessionsapi"
+	apiKeyPath := "/secret/data/accounts/gddt/sessionsapi"
 	log.SpanLog(ctx, log.DebugLevelDmereq, "GetApiKeyFromVault", "vaultAddr", vaultConfig.Addr, "apiKeyPath", apiKeyPath)
 	type ApiKeyData struct {
 		Data string

--- a/plugin/platform/operator-plugin.go
+++ b/plugin/platform/operator-plugin.go
@@ -17,6 +17,7 @@ package main
 import (
 	"context"
 
+	"github.com/edgexr/edge-cloud-infra/operator-api-gw/operalpha"
 	"github.com/edgexr/edge-cloud/d-match-engine/operator"
 	"github.com/edgexr/edge-cloud/d-match-engine/operator/defaultoperator"
 	"github.com/edgexr/edge-cloud/log"
@@ -27,6 +28,10 @@ func GetOperatorApiGw(ctx context.Context, operatorName string) (operator.Operat
 
 	var outApiGw operator.OperatorApiGw
 	switch operatorName {
+	case "gddt":
+		fallthrough
+	case "GDDT":
+		outApiGw = &operalpha.OperatorApiGw{}
 	default:
 		outApiGw = &defaultoperator.OperatorApiGw{}
 	}


### PR DESCRIPTION
Sensitive data was renamed, including data in test output. While renames were consistent across code and test files, unfortunately the renames changed the alphabetical sorting of objects, so objects in the test files need to be moved around back to proper sorted order for the diffs to match.